### PR TITLE
fixing glob loading in numpy helpers

### DIFF
--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -309,7 +309,6 @@ class File(BaseObject, Downloadable):
     ):
         """
         Downloads a sparsezoo file.
-        If the file_type is a data type then the downloaded tar file will be extracted
 
         :param overwrite: True to overwrite any previous file, False otherwise
         :param refresh_token: True to refresh the auth token, False otherwise

--- a/src/sparsezoo/utils/numpy.py
+++ b/src/sparsezoo/utils/numpy.py
@@ -139,13 +139,16 @@ def load_numpy_list(
     """
     loaded = []
 
-    if isinstance(data, str) and os.path.isdir(data):
-        data = sorted(glob.glob(data))
-    elif isinstance(data, str) and tarfile.is_tarfile(data):
-        data = load_numpy_from_tar(data)
-    elif isinstance(data, str):
-        # treat as a numpy file to load from
-        data = [load_numpy(data)]
+    if isinstance(data, str):
+        if os.path.isfile(data) and tarfile.is_tarfile(data):
+            data = load_numpy_from_tar(data)
+        elif os.path.isfile(data) and ".np" in data:
+            # treat as a numpy file to load from
+            data = [load_numpy(data)]
+        else:
+            # load from directory or glob
+            glob_path = os.path.join(data, "*") if os.path.isdir(data) else data
+            data = sorted(glob.glob(glob_path))
 
     for dat in data:
         if isinstance(dat, str):


### PR DESCRIPTION
`load_numpy_list` would previously throw errors on actual globs, and directories would not be correctly parsed by `glob.glob`