### PR TITLE
Makefile build command for nightly builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ DOCDIR := docs
 MDCHECKGLOBS := 'docs/**/*.md' 'docs/**/*.rst' 'examples/**/*.md' 'notebooks/**/*.md' 'scripts/**/*.md'
 MDCHECKFILES := CODE_OF_CONDUCT.md CONTRIBUTING.md DEVELOPING.md README.md
 
+BUILD_ARGS :=  # set nightly to build nightly release
 TARGETS := ""  # targets for running pytests: full,efficientnet,inception,resnet,vgg,ssd,yolo
 PYTEST_ARGS := ""
 ifneq ($(findstring full,$(TARGETS)),full)
@@ -61,7 +62,7 @@ docs:
 
 # creates wheel file
 build:
-	python3 setup.py sdist bdist_wheel
+	python3 setup.py sdist bdist_wheel $(BUILD_ARGS)
 
 # clean package
 clean:

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+from datetime import date
 from typing import Tuple, List, Dict
 from setuptools import find_packages, setup
+
+_PACKAGE_NAME = "sparsezoo"
+_VERSION = "0.1.0"
+_NIGHTLY = "nightly" in sys.argv
+
+if _NIGHTLY:
+    _PACKAGE_NAME += "-nightly"
+    _VERSION += "." + date.today().strftime("%Y%m%d")
+    # remove nightly param so it does not break bdist_wheel
+    sys.argv.remove("nightly")
 
 _deps = [
     "numpy>=1.0.0",
@@ -65,8 +77,8 @@ def _setup_long_description() -> Tuple[str, str]:
 
 
 setup(
-    name="sparsezoo",
-    version="0.1.0",
+    name=_PACKAGE_NAME,
+    version=_VERSION,
     author="Neuralmagic, Inc.",
     author_email="support@neuralmagic.com",
     description="Neural network model repository for highly sparse models "


### PR DESCRIPTION
this PR introduces a Makefile argument and modifies `setup.py` so nightly packages can be built with
```
make build BUILD_ARGS=nightly
```

`dist` directory contents after building:
```
sparsezoo_nightly-0.1.0.20210208-py3-none-any.whl  sparsezoo-nightly-0.1.0.20210208.tar.gz
```