### PR TITLE
Update for 0.1.1 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ from typing import Tuple, List, Dict
 from setuptools import find_packages, setup
 
 _PACKAGE_NAME = "sparsezoo"
-_VERSION = "0.1.0"
+_VERSION = "0.1.1"
+_VERSION_MAJOR, _VERSION_MINOR, _VERSION_BUG = _VERSION.split(".")
+_VERSION_MAJOR_MINOR = f"{_VERSION_MAJOR}.{_VERSION_MINOR}"
 _NIGHTLY = "nightly" in sys.argv
 
 if _NIGHTLY:


### PR DESCRIPTION
- update python version to 0.1.1
- setup.py add in version parts and _VERSION_MAJOR_MINOR for more flexibility with dependencies between neural magic packages