### PR TITLE
Get Model Path Intergation

### DIFF
--- a/.jenkins/enviroment_testing.jenkinsfile
+++ b/.jenkins/enviroment_testing.jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
     }
     parameters {
         string(name: 'TEST_API', defaultValue:"https://api.neuralmagic.com", description: 'Test API URL override')
+        string(name: 'BRANCH', defaultValue:"main", description: 'Branch to switch to test features')
     }
     stages {
         stage("setup") {
@@ -27,6 +28,7 @@ pipeline {
                     source ${VIRTUAL_ENV}/bin/activate
                     export SPARSEZOO_CREDENTIALS="credentials.yaml"
                     export SPARSEZOO_API_URL=${params.TEST_API}
+                    git checkout ${params.BRANCH}
                     make test
                     rm credentials.yaml
                 """

--- a/src/sparsezoo/main.py
+++ b/src/sparsezoo/main.py
@@ -291,6 +291,11 @@ def parse_args():
         help="The directory to save the model files in, "
         "defaults to the cwd with the model description as a sub folder",
     )
+    download_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrites existing model files if previously downloaded",
+    )
 
     search_parser.add_argument(
         "--page", type=int, default=1, help="The page of search results to view"
@@ -384,7 +389,7 @@ def main():
 
     if args.command == DOWNLOAD_COMMAND:
         LOGGER.info("Downloading files from model...")
-        model = Zoo.load_model(
+        dir_path = Zoo.download_model(
             domain=args.domain,
             sub_domain=args.sub_domain,
             architecture=args.architecture,
@@ -398,14 +403,13 @@ def main():
             optim_target=args.optim_target,
             release_version=args.release_version,
             override_parent_path=args.save_dir,
+            overwrite=args.overwrite,
         )
-        model.download()
 
         print("Download results")
         print("====================")
         print("")
-        print(model.stub)
-        print(f"downloaded to {model.dir_path}")
+        print(f"downloaded to {dir_path}")
     elif args.command == SEARCH_COMMAND:
         search(args)
 

--- a/src/sparsezoo/main.py
+++ b/src/sparsezoo/main.py
@@ -389,7 +389,7 @@ def main():
 
     if args.command == DOWNLOAD_COMMAND:
         LOGGER.info("Downloading files from model...")
-        dir_path = Zoo.download_model(
+        model = Zoo.download_model(
             domain=args.domain,
             sub_domain=args.sub_domain,
             architecture=args.architecture,
@@ -409,7 +409,7 @@ def main():
         print("Download results")
         print("====================")
         print("")
-        print(f"downloaded to {dir_path}")
+        print(f"downloaded to {model.dir_path}")
     elif args.command == SEARCH_COMMAND:
         search(args)
 

--- a/src/sparsezoo/models/zoo.py
+++ b/src/sparsezoo/models/zoo.py
@@ -204,7 +204,7 @@ class Zoo:
         override_parent_path: Union[str, None] = None,
         force_token_refresh: bool = False,
         overwrite: bool = False,
-    ) -> str:
+    ) -> Model:
         """
         Downloads a model from model repo
 
@@ -238,7 +238,7 @@ class Zoo:
             for where to save the parent folder for this file under
         :param force_token_refresh: True to refresh the auth token, False otherwise
         :param overwrite: True to overwrite the file if it exists, False otherwise
-        :return: The path where the models were downloaded
+        :return: The requested Model instance
         """
         args = ModelArgs(
             domain=domain,
@@ -269,7 +269,7 @@ class Zoo:
         override_parent_path: Union[str, None] = None,
         force_token_refresh: bool = False,
         overwrite: bool = False,
-    ) -> str:
+    ) -> Model:
         """
         :param stub: the SparseZoo stub path to the model, can be a string path or
             ModelArgs object
@@ -279,7 +279,7 @@ class Zoo:
             for where to save the parent folder for this file under
         :param force_token_refresh: True to refresh the auth token, False otherwise
         :param overwrite: True to overwrite the file if it exists, False otherwise
-        :return: The path where the model files were downloaded
+        :return: The requested Model instance
         """
         if isinstance(stub, str):
             stub, _ = parse_zoo_stub(stub, valid_params=[])
@@ -295,7 +295,7 @@ class Zoo:
             override_parent_path=override_parent_path,
         )
         model.download(overwrite=overwrite, refresh_token=force_token_refresh)
-        return model.dir_path
+        return model
 
     @staticmethod
     def search_models(

--- a/src/sparsezoo/models/zoo.py
+++ b/src/sparsezoo/models/zoo.py
@@ -104,7 +104,7 @@ class Zoo:
         force_token_refresh: bool = False,
     ) -> Model:
         """
-        Obtains a Model with signed files from the model repo
+        Obtains a Model from the model repo
 
         :param domain: The domain of the model the object belongs to;
             e.g. cv, nlp

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -25,7 +25,7 @@ from typing import Union
 from sparsezoo.objects.base import BaseObject
 from sparsezoo.objects.downloadable import Downloadable
 from sparsezoo.objects.metadata import ModelMetadata
-from sparsezoo.requests import download_get_request
+from sparsezoo.requests import download_model_get_request
 from sparsezoo.utils import create_parent_dirs, download_file
 
 
@@ -347,7 +347,7 @@ class File(BaseObject, Downloadable):
         self,
         refresh_token: bool = False,
     ) -> str:
-        response_json = download_get_request(
+        response_json = download_model_get_request(
             args=self.model_metadata,
             file_name=self.display_name,
             force_token_refresh=refresh_token,

--- a/src/sparsezoo/requests/__init__.py
+++ b/src/sparsezoo/requests/__init__.py
@@ -21,4 +21,5 @@ Classes for making requests with the sparsezoo
 from .authentication import *
 from .base import *
 from .download import *
+from .get import *
 from .search import *

--- a/src/sparsezoo/requests/download.py
+++ b/src/sparsezoo/requests/download.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Code related to wrapping around API calls under api.neuralmagic.com/objects/download
+Code related to wrapping around API calls under api.neuralmagic.com/[object]/download
 """
 
 import logging
@@ -45,9 +45,13 @@ def download_get_request(
     """
     Get a downloadable object from the sparsezoo for any objects matching the args
 
+    The path called has structure:
+        [base_url]/download/[args.stub]/{sub_path}
+
     :param base_url: the base url
     :param args: the model args describing what should be downloaded for
-    :param sub_path: the sub path from the model path if any
+    :param sub_path: the sub path from the model path if any e.g.
+        file_name for models api or recipe_type for the recipes api
     :param force_token_refresh: True to refresh the auth token, False otherwise
     :return: the json response as a dict
     """
@@ -74,7 +78,7 @@ def download_model_get_request(
     args: Union[ModelArgs, str],
     file_name: Union[str, None] = None,
     force_token_refresh: bool = False,
-):
+) -> Dict:
     """
     Get a downloadable model from the sparsezoo for any objects matching the args
 

--- a/src/sparsezoo/requests/get.py
+++ b/src/sparsezoo/requests/get.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Code related to wrapping around API calls under api.neuralmagic.com/objects/download
+Code related to wrapping around API calls under api.neuralmagic.com/[object]/get
 """
 
 import logging
@@ -35,15 +35,19 @@ GET_PATH = "get"
 def get_request(
     base_url: str,
     args: Union[ModelArgs, str],
-    file_name: Union[str, None] = None,
+    sub_path: Union[str, None] = None,
     force_token_refresh: bool = False,
 ) -> Dict:
     """
-    Get a downloadable object from the sparsezoo for any objects matching the args
+    Get an object from the sparsezoo for any objects matching the args.
+
+    The path called has structure:
+        [base_url]/get/[args.stub]/{sub_path}
 
     :param base_url: the base url of the request
-    :param args: the args describing what should be downloaded for
-    :param file_name: the name of the file, if any, to get download info for
+    :param args: the args describing what should be retrieved
+    :param file_name: the sub path from the model path if any e.g.
+        file_name for models api or recipe_type for the recipes api
     :param force_token_refresh: True to refresh the auth token, False otherwise
     :return: the json response as a dict
     """
@@ -51,8 +55,8 @@ def get_request(
     path = args if isinstance(args, str) else args.stub
     url = f"{base_url}/{GET_PATH}/{path}"
 
-    if file_name:
-        url = f"{url}/{file_name}"
+    if sub_path:
+        url = f"{url}/{sub_path}"
 
     if hasattr(args, "release_version") and args.release_version:
         url = f"{url}?release_version={args.release_version}"
@@ -72,16 +76,16 @@ def get_model_get_request(
     force_token_refresh: bool = False,
 ) -> Dict:
     """
-    Get a downloadable model from the sparsezoo for any objects matching the args
+    Get a model from the sparsezoo for any objects matching the args
 
-    :param args: the model args describing what should be downloaded for
-    :param file_name: the name of the file, if any, to get download info for
+    :param args: the model args describing what should be retrieved for
+    :param file_name: the name of the file, if any, to get model info for
     :param force_token_refresh: True to refresh the auth token, False otherwise
     :return: the json response as a dict
     """
     return get_request(
         MODELS_API_URL,
         args=args,
-        file_name=file_name,
+        sub_path=file_name,
         force_token_refresh=force_token_refresh,
     )

--- a/src/sparsezoo/requests/get.py
+++ b/src/sparsezoo/requests/get.py
@@ -25,38 +25,34 @@ from sparsezoo.requests.authentication import get_auth_header
 from sparsezoo.requests.base import MODELS_API_URL, ModelArgs
 
 
-__all__ = [
-    "download_get_request",
-    "download_model_get_request",
-    "DOWNLOAD_PATH",
-]
+__all__ = ["get_request", "get_model_get_request", "GET_PATH"]
 
 
 _LOGGER = logging.getLogger(__name__)
-DOWNLOAD_PATH = "download"
+GET_PATH = "get"
 
 
-def download_get_request(
+def get_request(
     base_url: str,
     args: Union[ModelArgs, str],
-    sub_path: Union[str, None] = None,
+    file_name: Union[str, None] = None,
     force_token_refresh: bool = False,
 ) -> Dict:
     """
     Get a downloadable object from the sparsezoo for any objects matching the args
 
-    :param base_url: the base url
-    :param args: the model args describing what should be downloaded for
-    :param sub_path: the sub path from the model path if any
+    :param base_url: the base url of the request
+    :param args: the args describing what should be downloaded for
+    :param file_name: the name of the file, if any, to get download info for
     :param force_token_refresh: True to refresh the auth token, False otherwise
     :return: the json response as a dict
     """
     header = get_auth_header(force_token_refresh=force_token_refresh)
     path = args if isinstance(args, str) else args.stub
-    url = f"{base_url}/{DOWNLOAD_PATH}/{path}"
+    url = f"{base_url}/{GET_PATH}/{path}"
 
-    if sub_path:
-        url = f"{url}/{sub_path}"
+    if file_name:
+        url = f"{url}/{file_name}"
 
     if hasattr(args, "release_version") and args.release_version:
         url = f"{url}?release_version={args.release_version}"
@@ -70,11 +66,11 @@ def download_get_request(
     return response_json
 
 
-def download_model_get_request(
+def get_model_get_request(
     args: Union[ModelArgs, str],
     file_name: Union[str, None] = None,
     force_token_refresh: bool = False,
-):
+) -> Dict:
     """
     Get a downloadable model from the sparsezoo for any objects matching the args
 
@@ -83,9 +79,9 @@ def download_model_get_request(
     :param force_token_refresh: True to refresh the auth token, False otherwise
     :return: the json response as a dict
     """
-    return download_get_request(
-        base_url=MODELS_API_URL,
+    return get_request(
+        MODELS_API_URL,
         args=args,
-        sub_path=file_name,
+        file_name=file_name,
         force_token_refresh=force_token_refresh,
     )

--- a/src/sparsezoo/requests/search.py
+++ b/src/sparsezoo/requests/search.py
@@ -25,7 +25,11 @@ from sparsezoo.requests.authentication import get_auth_header
 from sparsezoo.requests.base import MODELS_API_URL, ModelArgs
 
 
-__all__ = ["search_get_request", "SEARCH_PATH"]
+__all__ = [
+    "search_get_request",
+    "search_model_get_request",
+    "SEARCH_PATH",
+]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,6 +37,7 @@ SEARCH_PATH = "search"
 
 
 def search_get_request(
+    base_url: str,
     args: ModelArgs,
     page: int = 1,
     page_length: int = 20,
@@ -41,6 +46,7 @@ def search_get_request(
     """
     Search the sparsezoo for any objects matching the args
 
+    :param base_url: the base url
     :param args: the model args describing what should be searched for
     :param page: the page of values to get
     :param page_length: the page length of values to get
@@ -62,9 +68,33 @@ def search_get_request(
         search_args.extend(f"release_version={args.release_version}")
 
     search_args = "&".join(search_args)
-    url = f"{MODELS_API_URL}/{SEARCH_PATH}/{args.model_url_root}?{search_args}"
+    url = f"{base_url}/{SEARCH_PATH}/{args.model_url_root}?{search_args}"
 
     _LOGGER.info(f"Searching objects from {url}")
     response_json = requests.get(url=url, headers=header).json()
 
     return response_json
+
+
+def search_model_get_request(
+    args: ModelArgs,
+    page: int = 1,
+    page_length: int = 20,
+    force_token_refresh: bool = False,
+) -> Dict:
+    """
+    Search the sparsezoo for any models matching the args
+
+    :param args: the model args describing what should be searched for
+    :param page: the page of values to get
+    :param page_length: the page length of values to get
+    :param force_token_refresh: True to refresh the auth token, False otherwise
+    :return: the json response as a dict
+    """
+    return search_get_request(
+        base_url=MODELS_API_URL,
+        args=args,
+        page=page,
+        page_length=page_length,
+        force_token_refresh=force_token_refresh,
+    )

--- a/tests/sparsezoo/models/test_zoo.py
+++ b/tests/sparsezoo/models/test_zoo.py
@@ -70,6 +70,54 @@ def test_load_model(model_args, other_args):
 
 
 @pytest.mark.parametrize(
+    "model_args,other_args",
+    [
+        (
+            {
+                "domain": "cv",
+                "sub_domain": "classification",
+                "architecture": "mobilenet_v1",
+                "sub_architecture": "1.0",
+                "framework": "pytorch",
+                "repo": "sparseml",
+                "dataset": "imagenet",
+                "training_scheme": None,
+                "optim_name": "base",
+                "optim_category": "none",
+                "optim_target": None,
+            },
+            {
+                "override_parent_path": os.path.join(CACHE_DIR, "test_download"),
+                "override_folder_name": "test_folder",
+            },
+        ),
+        (
+            {
+                "domain": "cv",
+                "sub_domain": "classification",
+                "architecture": "mobilenet_v1",
+                "sub_architecture": "1.0",
+                "framework": "pytorch",
+                "repo": "sparseml",
+                "dataset": "imagenet",
+                "training_scheme": None,
+                "optim_name": "base",
+                "optim_category": "none",
+                "optim_target": None,
+            },
+            {},
+        ),
+    ],
+)
+def test_download_model(model_args, other_args):
+    path = Zoo.download_model(**model_args, **other_args)
+    model = Zoo.load_model(**model_args, **other_args)
+    assert path == model.dir_path
+    validate_downloaded_model(model, model_args, other_args)
+    shutil.rmtree(model.dir_path)
+
+
+@pytest.mark.parametrize(
     "stub, model_args, other_args",
     [
         [

--- a/tests/sparsezoo/models/test_zoo.py
+++ b/tests/sparsezoo/models/test_zoo.py
@@ -110,9 +110,7 @@ def test_load_model(model_args, other_args):
     ],
 )
 def test_download_model(model_args, other_args):
-    path = Zoo.download_model(**model_args, **other_args)
-    model = Zoo.load_model(**model_args, **other_args)
-    assert path == model.dir_path
+    model = Zoo.download_model(**model_args, **other_args)
     validate_downloaded_model(model, model_args, other_args)
     shutil.rmtree(model.dir_path)
 


### PR DESCRIPTION
- Added get path for obtaining a model
- Moved model specific requests to  `download_model_get_request` and `search_model_get_request` to make former method a generic subpath e.g. recipes
- Added `download_model` and `download_model_from_stub` to directly download a model when returning the model isn't necessary. 
- Changed `load_model` and `load_model_from_stub` to use `get_model_get_request` for obtaining faster