### PR TITLE
Add version.py and exec in setup.py and docs conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,6 @@
 import os
 import sys
 
-from sparsezoo import __version__
-
 sys.path.insert(0, os.path.abspath("../.."))
 
 
@@ -28,9 +26,13 @@ copyright = (
 author = "Neural Magic"
 
 # The full version, including alpha/beta/rc tags
-ver_major, ver_minor, ver_bug = __version__.split(".")
-version = f"{ver_major}.{ver_minor}"
-release = __version__
+version = "unknown"
+version_major_minor = version
+# load and overwrite version info from sparseml package
+exec(open(os.path.join(os.pardir, os.pardir, "src", "sparsezoo", "version.py")).read())
+release = version
+version = version_major_minor
+print(f"loaded versions from src/sparsezoo/version.py and set to {release}, {version}")
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -12,22 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 from datetime import date
 from typing import Tuple, List, Dict
 from setuptools import find_packages, setup
 
-from sparsezoo import __version__
+version = "unknown"
+version_major_minor = version
+# load and overwrite version info from sparseml package
+exec(open(os.path.join("src", "sparsezoo", "version.py")).read())
+print(f"loaded version {version} from src/sparsezoo/version.py")
 
 _PACKAGE_NAME = "sparsezoo"
-_VERSION = __version__
-_VERSION_MAJOR, _VERSION_MINOR, _VERSION_BUG = _VERSION.split(".")
-_VERSION_MAJOR_MINOR = f"{_VERSION_MAJOR}.{_VERSION_MINOR}"
 _NIGHTLY = "nightly" in sys.argv
 
 if _NIGHTLY:
     _PACKAGE_NAME += "-nightly"
-    _VERSION += "." + date.today().strftime("%Y%m%d")
+    version += "." + date.today().strftime("%Y%m%d")
     # remove nightly param so it does not break bdist_wheel
     sys.argv.remove("nightly")
 
@@ -82,7 +84,7 @@ def _setup_long_description() -> Tuple[str, str]:
 
 setup(
     name=_PACKAGE_NAME,
-    version=_VERSION,
+    version=version,
     author="Neuralmagic, Inc.",
     author_email="support@neuralmagic.com",
     description=(

--- a/src/sparsezoo/version.py
+++ b/src/sparsezoo/version.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 # Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,13 +13,12 @@
 # limitations under the License.
 
 """
-Functionality for accessing models, recipes, and supporting files in the SparseZoo
+Functionality for storing and setting the version info for SparseML
 """
 
-# flake8: noqa
-# isort: skip_file
+__all__ = ["__version__"]
+__version__ = "0.2.0"
 
-from .version import *
-from .main import *
-from .models.zoo import *
-from .objects import *
+version = __version__
+version_major, version_minor, version_bug = version.split(".")
+version_major_minor = f"{version_major}.{version_minor}"

--- a/src/sparsezoo/version.py
+++ b/src/sparsezoo/version.py
@@ -13,10 +13,17 @@
 # limitations under the License.
 
 """
-Functionality for storing and setting the version info for SparseML
+Functionality for storing and setting the version info for SparseZoo
 """
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "version",
+    "version_major",
+    "version_minor",
+    "version_bug",
+    "version_major_minor",
+]
 __version__ = "0.2.0"
 
 version = __version__


### PR DESCRIPTION
Changing so that we don't have a requirement of the user setting the pythonpath for builds and docs to work with new version