### PR TITLE
Add:Support for batched iteration

### DIFF
--- a/src/sparsezoo/utils/data.py
+++ b/src/sparsezoo/utils/data.py
@@ -77,27 +77,17 @@ class Dataset(Iterable):
 
         :return: A batch generator for self.data
         """
-        assert iterations >= 0, "number of iterations should be positive"
-        assert (
-            self._data.shape[0] >= batch_size >= 0
-        ), "batch_size should be positive and less than or equal to the  size of data"
-
-        _dataset = self._data
-
-        # handle 1-d numpy arrays
-        if len(_dataset.shape) == 1:
-            _dataset = _dataset.reshape(_dataset.shape[0], 1)
-
+        dataset = self._data
         iteration = 0
         batch_buffer = []
         batch_template = [
             numpy.ascontiguousarray(
                 numpy.zeros((batch_size, *array.shape), dtype=array.dtype)
             )
-            for array in _dataset[0]
+            for array in dataset[0]
         ]
         while iteration < iterations:
-            for sample in _dataset:
+            for sample in dataset:
                 batch_buffer.append(sample)
 
                 if len(batch_buffer) == batch_size:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -18,17 +18,21 @@ import pytest as pytest
 from sparsezoo.utils import Dataset
 
 
-@pytest.fixture
-def dummy_dataset():
-    _dummy_array_1 = np.random.rand(2, 3)
-    _dummy_array_2 = np.random.rand(34, 3)
-    return Dataset(data=[_dummy_array_1, _dummy_array_2], name="dummy")
+@pytest.mark.parametrize(
+    "dataset",
+    [Dataset(data=(np.random.rand(2, 45), np.random.rand(2, 45)), name="tuple")],
+)
+def test_has_iter_batches(dataset):
+    assert hasattr(dataset, "iter_batches")
 
 
-def test_has_iter_batches(dummy_dataset):
-    assert hasattr(dummy_dataset, "iter_batches")
-
-
+@pytest.mark.parametrize(
+    "dataset",
+    [
+        Dataset(data=[np.random.rand(2, 45), np.random.rand(2, 45)], name="list"),
+        Dataset(data=(np.random.rand(2, 45), np.random.rand(2, 45)), name="tuple"),
+    ],
+)
 @pytest.mark.parametrize(
     "batch_size",
     [
@@ -47,11 +51,9 @@ def test_has_iter_batches(dummy_dataset):
         100,
     ],
 )
-def test_batched_iteration(dummy_dataset, batch_size, iterations):
-    data_loader = dummy_dataset.iter_batches(
-        batch_size=batch_size, iterations=iterations
-    )
-    data_shape = dummy_dataset.data[0].shape
+def test_batched_iteration(dataset, batch_size, iterations):
+    data_loader = dataset.iter_batches(batch_size=batch_size, iterations=iterations)
+    data_shape = dataset.data[0].shape
 
     for iteration, batch in enumerate(data_loader):
         batch_element_shape = batch[0].shape

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest as pytest
+
+from sparsezoo.utils import Dataset
+
+
+@pytest.mark.parametrize(
+    "_data",
+    [
+        Dataset(data=np.empty(shape=(100, 100, 10, 10)), name="4d"),
+    ],
+)
+def test_has_iter_batches(_data):
+    assert hasattr(_data, "iter_batches")
+
+
+@pytest.mark.parametrize(
+    "_data",
+    [
+        Dataset(data=np.empty(shape=(100, 100, 10, 10)), name="4d"),
+        Dataset(data=np.empty(shape=(100, 100, 10)), name="3d"),
+        Dataset(data=np.empty(shape=(100, 10)), name="2d"),
+        Dataset(data=np.empty(shape=(100,)), name="1d"),
+    ],
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    [
+        1,
+        10,
+        100,
+    ],
+)
+@pytest.mark.parametrize(
+    "iterations",
+    [
+        1,
+        10,
+        100,
+    ],
+)
+def test_batched_iteration(_data, batch_size, iterations):
+    data_loader = _data.iter_batches(batch_size=batch_size, iterations=iterations)
+    data_shape = _data.data.shape
+
+    # fix 1-d numpy array shape
+    if len(data_shape) == 1:
+        data_shape = (data_shape[0], 1)
+
+    for iteration, batch in enumerate(data_loader):
+        batch_shape = batch[0].shape
+
+        assert isinstance(batch, list)
+        assert len(batch) == data_shape[1]
+        assert len(batch_shape) == len(data_shape) - 1
+        assert all([a == b for a, b in zip(batch_shape[1:], data_shape[2:])])
+
+    assert iteration + 1 == iterations


### PR DESCRIPTION
This pull request adds support for batched iteration,
Let me know if more tests are needed.

Implementation adapted from: [YoloV3 benchmarking DeepSparse](https://github.com/neuralmagic/deepsparse/blob/main/examples/ultralytics-yolov3/benchmark.py#L384)