### PR TITLE
Add:Support for ONNX versions 1.8.*, 1.9.*, upto 1.10.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ _PACKAGE_NAME = "sparsezoo" if is_release else "sparsezoo-nightly"
 
 _deps = [
     "numpy>=1.0.0",
-    "onnx>=1.0.0,<1.8.0",
+    "onnx>=1.0.0,<=1.10.1",
     "pyyaml>=5.1.0",
     "requests>=2.0.0",
     "tqdm>=4.0.0",


### PR DESCRIPTION
Some tests fail on running make test due to HTTPError 403, potentially due to requests library

The failing tests are limited to `tests/sparsezoo/models/test_zoo.py` and `tests/sparsezoo/models/test_zoo_extensive.py`
