### PR TITLE
version-api-pypi integration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ optional arguments:
 """
 
 import os
-from typing import Tuple, List, Dict
+from typing import Dict, List, Tuple
+
 from setuptools import find_packages, setup
 
 # default variables to be overwritten by the version.py file

--- a/src/sparsezoo/__init__.py
+++ b/src/sparsezoo/__init__.py
@@ -33,5 +33,5 @@ from sparsezoo.package import check_package_version as _check_package_version
 
 _check_package_version(
     package_name=__name__ if is_release else f"{__name__}-nightly",
-    package_version=version_base,
+    package_version=version,
 )

--- a/src/sparsezoo/__init__.py
+++ b/src/sparsezoo/__init__.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 """
-Functionality for accessing models, recipes, and supporting files in the SparseZoo
+- Functionality for accessing models, recipes, and supporting files in the SparseZoo
+- Notify the user the last pypi package version
 """
 
 # flake8: noqa
@@ -25,3 +26,59 @@ from .version import *
 from .main import *
 from .models.zoo import *
 from .objects import *
+
+from .requests.base import LATEST_PACKAGE_VERSION_URL
+
+import logging
+import requests
+import threading
+import os
+
+_LOGGER = logging.getLogger(__name__)
+
+def _version_check(package_name, package_version, package_integration):
+    url = f"{LATEST_PACKAGE_VERSION_URL}?"\
+        f"packages={package_name}"\
+        f"&versions={package_version}"\
+        f"&integrations={package_integration}"
+    try:
+        response = requests.get(url)  # no token-headers required
+        response.raise_for_status()
+
+        response_json = response.json()
+        for checkedPackage in response_json["checkedPackages"]:
+            if not checkedPackage["isLatest"]:
+                _LOGGER.warning(
+                    "WARNING: "\
+                    f"You are using {checkedPackage['packageName']} "\
+                    f"version {checkedPackage['userVersion']} "\
+                    f"however version {checkedPackage['latestVersion']} "\
+                    "is available.\n"\
+                    "You should consider upgrading via executing the "\
+                    f"'pip install {checkedPackage['packageName']}'"\
+                    "command"
+                )
+                _LOGGER.warning(
+                    "WARNING: "\
+                    "To turn off version check, set an environmental variable " \
+                    "NM_VERSION_CHECK=false"\
+                )
+    except:
+        pass
+
+package_integration = "HuggingFace"  # temp holder
+
+# Run thread in the background
+if os.getenv("NM_VERSION_CHECK") == None or os.getenv("NM_VERSION_CHECK").lower().strip() != 'false':
+    threading.Thread(
+        target=_version_check,
+        kwargs={
+            "package_name": __name__,
+            "package_version": version,
+            "package_integration": package_integration,
+        },
+    ).start()
+else:
+    print('skipping version check')
+
+

--- a/src/sparsezoo/__init__.py
+++ b/src/sparsezoo/__init__.py
@@ -26,59 +26,11 @@ from .version import *
 from .main import *
 from .models.zoo import *
 from .objects import *
-
-from .requests.base import LATEST_PACKAGE_VERSION_URL
-
-import logging
-import requests
-import threading
-import os
-
-_LOGGER = logging.getLogger(__name__)
-
-def _version_check(package_name, package_version, package_integration):
-    url = f"{LATEST_PACKAGE_VERSION_URL}?"\
-        f"packages={package_name}"\
-        f"&versions={package_version}"\
-        f"&integrations={package_integration}"
-    try:
-        response = requests.get(url)  # no token-headers required
-        response.raise_for_status()
-
-        response_json = response.json()
-        for checkedPackage in response_json["checkedPackages"]:
-            if not checkedPackage["isLatest"]:
-                _LOGGER.warning(
-                    "WARNING: "\
-                    f"You are using {checkedPackage['packageName']} "\
-                    f"version {checkedPackage['userVersion']} "\
-                    f"however version {checkedPackage['latestVersion']} "\
-                    "is available.\n"\
-                    "You should consider upgrading via executing the "\
-                    f"'pip install {checkedPackage['packageName']}'"\
-                    "command"
-                )
-                _LOGGER.warning(
-                    "WARNING: "\
-                    "To turn off version check, set an environmental variable " \
-                    "NM_VERSION_CHECK=false"\
-                )
-    except:
-        pass
-
-package_integration = "HuggingFace"  # temp holder
-
-# Run thread in the background
-if os.getenv("NM_VERSION_CHECK") == None or os.getenv("NM_VERSION_CHECK").lower().strip() != 'false':
-    threading.Thread(
-        target=_version_check,
-        kwargs={
-            "package_name": __name__,
-            "package_version": version,
-            "package_integration": package_integration,
-        },
-    ).start()
-else:
-    print('skipping version check')
+from .package import *
 
 
+from sparsezoo.package import check_package_version as _check_package_version
+
+_check_package_version(
+    package_name=__name__, package_integration="Null", package_version=version_base
+)

--- a/src/sparsezoo/__init__.py
+++ b/src/sparsezoo/__init__.py
@@ -32,5 +32,6 @@ from .package import *
 from sparsezoo.package import check_package_version as _check_package_version
 
 _check_package_version(
-    package_name=__name__, package_integration="Null", package_version=version_base
+    package_name=__name__ if is_release else f"{__name__}-nightly",
+    package_version=version_base,
 )

--- a/src/sparsezoo/package.py
+++ b/src/sparsezoo/package.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import threading
+
+import requests
+
+from sparsezoo.requests import LATEST_PACKAGE_VERSION_URL
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def package_version_check_request(
+    package_name: str, package_integration: str, package_version: str
+):
+    """
+    Make an api call to api-neuralmagic.com, retrieve payload and check if the
+    user is on the latest package version. Lambda: nm-get-latest-version
+
+    :param package_name: package name of the client
+    :param package_version: package version of the client
+    :param package_integration: package integration of the client
+    """
+    url = (
+        f"{LATEST_PACKAGE_VERSION_URL}?"
+        f"packages={package_name}"
+        f"&integrations={package_integration}"
+        f"&versions={package_version}"
+    )
+    try:
+        response = requests.get(url)  # no token-headers required
+        response.raise_for_status()
+        response_json = response.json()
+
+        for checked_package in response_json["checked_packages"]:
+            if not checked_package["is_latest"]:
+                LOGGER.warning(
+                    "WARNING: "
+                    f"You are using {checked_package['package_name']} "
+                    f"version {checked_package['user_package_version']} "
+                    f"however version {checked_package['latest_package_version']} "
+                    "is available.\n"
+                    "Consider upgrading via executing the "
+                    f"'pip install {checked_package['package_name']}' "
+                    "command.\n"
+                    "To turn off set an environmental variable "
+                    "NM_VERSION_CHECK=false"
+                )
+    except Exception as err:
+        raise RuntimeError(
+            f"Execption occured in the Neural Magic's internal version-api check\n{err}"
+        )
+
+
+def version_check_execution_condition(
+    package_name: str, package_integration: str, package_version: str
+):
+    """
+    Check if conditions are met to run the version-check api
+
+    :param package_name: package name of the client
+    :param package_version: package version of the client
+    :param package_integration: package integration of the client
+    """
+    if (
+        os.getenv("NM_VERSION_CHECK") is None
+        or os.getenv("NM_VERSION_CHECK").lower().strip() != "false"
+    ):
+        package_version_check_request(
+            package_name=package_name,
+            package_integration=package_integration,
+            package_version=package_version,
+        )
+    else:
+        LOGGER.info(
+            "Skipping Neural Magic's internal code exection: "
+            "latest package version check"
+        )
+
+
+def check_package_version(
+    package_name: str, package_version: str, package_integration: str
+):
+    """
+    Run a background thread to run version-check api
+
+    :param package_name: package name of the client
+    :param package_version: package version of the client
+    :param package_integration: package integration of the client
+    """
+    threading.Thread(
+        target=version_check_execution_condition,
+        kwargs={
+            "package_name": package_name,
+            "package_integration": package_integration,
+            "package_version": package_version,
+        },
+    ).start()

--- a/src/sparsezoo/package.py
+++ b/src/sparsezoo/package.py
@@ -55,8 +55,7 @@ def package_version_check_request(
                     f"however version {checked_package['latest_package_version']} "
                     "is available.\n"
                     "Consider upgrading via executing the "
-                    f"'pip install {checked_package['package_name']}' "
-                    "command.\n"
+                    f"'pip install --upgrade' command.\n"
                     "To turn off set an environmental variable "
                     "NM_VERSION_CHECK=false"
                 )

--- a/src/sparsezoo/package.py
+++ b/src/sparsezoo/package.py
@@ -15,6 +15,7 @@
 import logging
 import os
 import threading
+from typing import Optional
 
 import requests
 
@@ -25,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def package_version_check_request(
-    package_name: str, package_integration: str, package_version: str
+    package_name: str, package_version: str, package_integration: Optional[str]
 ):
     """
     Make an api call to api-neuralmagic.com, retrieve payload and check if the
@@ -66,7 +67,7 @@ def package_version_check_request(
 
 
 def version_check_execution_condition(
-    package_name: str, package_integration: str, package_version: str
+    package_name: str, package_version: str, package_integration: Optional[str]
 ):
     """
     Check if conditions are met to run the version-check api
@@ -92,7 +93,7 @@ def version_check_execution_condition(
 
 
 def check_package_version(
-    package_name: str, package_version: str, package_integration: str
+    package_name: str, package_version: str, package_integration: Optional[str] = None
 ):
     """
     Run a background thread to run version-check api
@@ -105,7 +106,7 @@ def check_package_version(
         target=version_check_execution_condition,
         kwargs={
             "package_name": package_name,
-            "package_integration": package_integration,
             "package_version": package_version,
+            "package_integration": package_integration,
         },
     ).start()

--- a/src/sparsezoo/requests/base.py
+++ b/src/sparsezoo/requests/base.py
@@ -31,6 +31,7 @@ __all__ = [
     "RecipeArgs",
     "RECIPES_API_URL",
     "parse_zoo_stub",
+    "LATEST_PACKAGE_VERSION_URL",
 ]
 
 

--- a/src/sparsezoo/requests/base.py
+++ b/src/sparsezoo/requests/base.py
@@ -43,6 +43,7 @@ BASE_API_URL = (
 )
 MODELS_API_URL = f"{BASE_API_URL}/models"
 RECIPES_API_URL = f"{BASE_API_URL}/recipes"
+LATEST_PACKAGE_VERSION_URL = f"{BASE_API_URL}/packages/check-latest"
 
 # optional prefix for stubs
 ZOO_STUB_PREFIX = "zoo:"

--- a/src/sparsezoo/version.py
+++ b/src/sparsezoo/version.py
@@ -16,8 +16,16 @@
 Functionality for storing and setting the version info for SparseZoo
 """
 
+
+import logging
 from datetime import date
 
+import requests
+
+from sparsezoo.requests.base import LATEST_PACKAGE_VERSION_URL
+
+
+_LOGGER = logging.getLogger(__name__)
 
 version_base = "0.9.0"
 is_release = False  # change to True to set the generated version as a release version
@@ -29,6 +37,25 @@ def _generate_version():
         if is_release
         else f"{version_base}.{date.today().strftime('%Y%m%d')}"
     )
+
+
+def _version_check(version, package_name, package_integration):
+
+    url = f"{LATEST_PACKAGE_VERSION_URL}/\
+        packages={package_name}\
+        &versions={version}\
+        &integrations={package_integration}"
+    response = requests.get(url)  # no token-headers required
+    response.raise_for_status()
+
+    response_json = response.json()
+    for checkedPackage in response_json["checkedPackages"]:
+        if not checkedPackage["isLatest"]:
+            _LOGGER.warning(
+                f"Latest version {checkedPackage.isLatestVersion} \
+                available for {checkedPackage.packageName}. \
+                Current version {checkedPackage.userVersion}"
+            )
 
 
 __all__ = [
@@ -48,3 +75,6 @@ version_major, version_minor, version_bug, version_build = version.split(".") + 
     [None] if len(version.split(".")) < 4 else []
 )  # handle conditional for version being 3 parts or 4 (4 containing build date)
 version_major_minor = f"{version_major}.{version_minor}"
+
+
+# thread running in the background to run [_version_check] here

--- a/src/sparsezoo/version.py
+++ b/src/sparsezoo/version.py
@@ -17,16 +17,8 @@ Functionality for storing and setting the version info for SparseZoo
 """
 
 
-import logging
-import threading
+
 from datetime import date
-
-import requests
-
-from sparsezoo.requests.base import LATEST_PACKAGE_VERSION_URL
-
-
-_LOGGER = logging.getLogger(__name__)
 
 version_base = "0.9.0"
 is_release = False  # change to True to set the generated version as a release version
@@ -38,25 +30,6 @@ def _generate_version():
         if is_release
         else f"{version_base}.{date.today().strftime('%Y%m%d')}"
     )
-
-
-def _version_check(package_name, package_version, package_integration):
-
-    url = f"{LATEST_PACKAGE_VERSION_URL}/\
-        packages={package_name}\
-        &versions={package_version}\
-        &integrations={package_integration}"
-    response = requests.get(url)  # no token-headers required
-    response.raise_for_status()
-
-    response_json = response.json()
-    for checkedPackage in response_json["checkedPackages"]:
-        if not checkedPackage["isLatest"]:
-            _LOGGER.warning(
-                f"Latest version {checkedPackage.isLatestVersion} \
-                available for {checkedPackage.packageName}. \
-                Current version {checkedPackage.userVersion}"
-            )
 
 
 __all__ = [
@@ -76,15 +49,3 @@ version_major, version_minor, version_bug, version_build = version.split(".") + 
     [None] if len(version.split(".")) < 4 else []
 )  # handle conditional for version being 3 parts or 4 (4 containing build date)
 version_major_minor = f"{version_major}.{version_minor}"
-
-
-package_integration = ""  # temp holder
-
-threading.Thread(
-    target=_version_check,
-    kwargs={
-        "package_name": __name__,
-        "package_version": version,
-        "package_integration": package_integration,
-    },
-).start()

--- a/src/sparsezoo/version.py
+++ b/src/sparsezoo/version.py
@@ -17,8 +17,8 @@ Functionality for storing and setting the version info for SparseZoo
 """
 
 
-
 from datetime import date
+
 
 version_base = "0.9.0"
 is_release = False  # change to True to set the generated version as a release version

--- a/src/sparsezoo/version.py
+++ b/src/sparsezoo/version.py
@@ -18,6 +18,7 @@ Functionality for storing and setting the version info for SparseZoo
 
 
 import logging
+import threading
 from datetime import date
 
 import requests
@@ -39,11 +40,11 @@ def _generate_version():
     )
 
 
-def _version_check(version, package_name, package_integration):
+def _version_check(package_name, package_version, package_integration):
 
     url = f"{LATEST_PACKAGE_VERSION_URL}/\
         packages={package_name}\
-        &versions={version}\
+        &versions={package_version}\
         &integrations={package_integration}"
     response = requests.get(url)  # no token-headers required
     response.raise_for_status()
@@ -77,4 +78,13 @@ version_major, version_minor, version_bug, version_build = version.split(".") + 
 version_major_minor = f"{version_major}.{version_minor}"
 
 
-# thread running in the background to run [_version_check] here
+package_integration = ""  # temp holder
+
+threading.Thread(
+    target=_version_check,
+    kwargs={
+        "package_name": __name__,
+        "package_version": version,
+        "package_integration": package_integration,
+    },
+).start()


### PR DESCRIPTION
Completed: 
- Added get request for the version-api lambda's with the package_name and the package_version and temp holder of package_integration
 - Warns the user/client if they are not on the latest version
- Run the api call in the background process using thread
- Environmental variable to turn on/off the api-call
- Make a call to staging-api.neuralmagic.com and save client info to staging DB

To-dos:
- figure out how to put in the package_integration info
- Add integration to other packages