### PR TITLE
Mark recently intermittent tests as flaky

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ ensure_newline_before_comments = True
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = sparsezoo,tests
-known_third_party = bs4,requests,packaging,yaml,tqdm,numpy,onnx,pytest
+known_third_party = bs4,requests,packaging,yaml,tqdm,numpy,onnx,pytest,flaky
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 line_length = 88

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ _dev_deps = [
     "beautifulsoup4==4.9.3",
     "black>=20.8b1",
     "flake8>=3.8.3",
+    "flaky>=3.7.0",
     "isort>=5.7.0",
     "m2r2~=0.2.7",
     "myst-parser~=0.14.0",

--- a/tests/sparsezoo/models/classification/test_mobilenet.py
+++ b/tests/sparsezoo/models/classification/test_mobilenet.py
@@ -11,12 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import pytest
+from flaky import flaky
 
 from sparsezoo.models.classification import mobilenet_v1, mobilenet_v2
 from tests.sparsezoo.helpers import model_constructor
 
 
+@flaky(max_runs=3)
 @pytest.mark.parametrize(
     "download,framework,repo,dataset,training_scheme,"
     "sparse_name,sparse_category,sparse_target",

--- a/tests/sparsezoo/models/classification/test_mobilenet.py
+++ b/tests/sparsezoo/models/classification/test_mobilenet.py
@@ -19,7 +19,7 @@ from sparsezoo.models.classification import mobilenet_v1, mobilenet_v2
 from tests.sparsezoo.helpers import model_constructor
 
 
-@flaky(max_runs=3)
+@flaky
 @pytest.mark.parametrize(
     "download,framework,repo,dataset,training_scheme,"
     "sparse_name,sparse_category,sparse_target",

--- a/tests/sparsezoo/models/classification/test_resnet.py
+++ b/tests/sparsezoo/models/classification/test_resnet.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+from flaky import flaky
 
 from sparsezoo.models.classification import (
     resnet_18,
@@ -60,6 +61,7 @@ def test_resnet_18(
     )
 
 
+@flaky(max_runs=3)
 @pytest.mark.parametrize(
     (
         "download,framework,repo,dataset,training_scheme,"
@@ -127,6 +129,7 @@ def test_resnet_50(
     )
 
 
+@flaky(max_runs=3)
 @pytest.mark.parametrize(
     (
         "download,framework,repo,dataset,training_scheme,"

--- a/tests/sparsezoo/models/classification/test_resnet.py
+++ b/tests/sparsezoo/models/classification/test_resnet.py
@@ -61,7 +61,7 @@ def test_resnet_18(
     )
 
 
-@flaky(max_runs=3)
+@flaky
 @pytest.mark.parametrize(
     (
         "download,framework,repo,dataset,training_scheme,"
@@ -129,7 +129,7 @@ def test_resnet_50(
     )
 
 
-@flaky(max_runs=3)
+@flaky
 @pytest.mark.parametrize(
     (
         "download,framework,repo,dataset,training_scheme,"

--- a/tests/sparsezoo/models/test_zoo.py
+++ b/tests/sparsezoo/models/test_zoo.py
@@ -16,6 +16,7 @@ import os
 import shutil
 
 import pytest
+from flaky import flaky
 
 from sparsezoo import Zoo
 from sparsezoo.utils import CACHE_DIR
@@ -115,6 +116,7 @@ def test_download_model(model_args, other_args):
     shutil.rmtree(model.dir_path)
 
 
+@flaky(max_runs=3)
 @pytest.mark.parametrize(
     "stub, model_args, other_args",
     [
@@ -401,6 +403,7 @@ def test_search_sparse_recipes_from_stub(model_stub, other_args):
         assert recipe.model_metadata.training_scheme == model.training_scheme
 
 
+@flaky(max_runs=3)
 @pytest.mark.parametrize(
     "recipe_args,other_args",
     [

--- a/tests/sparsezoo/models/test_zoo.py
+++ b/tests/sparsezoo/models/test_zoo.py
@@ -116,7 +116,7 @@ def test_download_model(model_args, other_args):
     shutil.rmtree(model.dir_path)
 
 
-@flaky(max_runs=3)
+@flaky
 @pytest.mark.parametrize(
     "stub, model_args, other_args",
     [
@@ -403,7 +403,7 @@ def test_search_sparse_recipes_from_stub(model_stub, other_args):
         assert recipe.model_metadata.training_scheme == model.training_scheme
 
 
-@flaky(max_runs=3)
+@flaky
 @pytest.mark.parametrize(
     "recipe_args,other_args",
     [

--- a/tests/sparsezoo/models/test_zoo_extensive.py
+++ b/tests/sparsezoo/models/test_zoo_extensive.py
@@ -15,6 +15,7 @@
 from typing import List
 
 import pytest
+from flaky import flaky
 
 from sparsezoo.models import Zoo
 from tests.sparsezoo.helpers import download_and_verify
@@ -32,6 +33,7 @@ def _get_models(domain, sub_domain) -> List[str]:
     return [model.stub for model in models]
 
 
+@flaky(max_runs=3)
 @pytest.mark.parametrize(("model"), _get_models("cv", "classification"))
 def test_classification_models(model):
     download_and_verify(model)

--- a/tests/sparsezoo/models/test_zoo_extensive.py
+++ b/tests/sparsezoo/models/test_zoo_extensive.py
@@ -33,7 +33,7 @@ def _get_models(domain, sub_domain) -> List[str]:
     return [model.stub for model in models]
 
 
-@flaky(max_runs=3)
+@flaky
 @pytest.mark.parametrize(("model"), _get_models("cv", "classification"))
 def test_classification_models(model):
     download_and_verify(model)


### PR DESCRIPTION
In order to prevent any transient network issues from showing false failures in our standard test runs, the tests that recently intermittently failed have been decorated as `@flaky(max_runs=3)`.

ℹ️ **Note:** This required adding `flaky` as a new dev dependency to the repo.