### PR TITLE
Add: A `__repr__` method to `<sparsezoo.objects.base.BaseObject>`

### DIFF
--- a/src/sparsezoo/objects/base.py
+++ b/src/sparsezoo/objects/base.py
@@ -86,3 +86,16 @@ class BaseObject:
 
     def _get_properties(self) -> List[str]:
         return list(vars(self).keys())
+
+    def __repr__(self):
+        def _strip_underscores(_name: str):
+            return _name.lstrip("_").rstrip("_")
+
+        return (
+            f"{self.__class__.__qualname__}("
+            + ", ".join(
+                f"{_strip_underscores(attribute)}={value}"
+                for attribute, value in vars(self).items()
+            )
+            + ")"
+        )


### PR DESCRIPTION
Add: A repr method to `<sparsezoo.objects.base.BaseObject>` to display relevant information about the object

On running the following code snippet
```python
from sparsezoo import Zoo

model_stub = "zoo:cv/detection/yolo_v3-spp/pytorch/ultralytics/coco/base-none"
model = Zoo.download_model_from_stub(model_stub)

for file in model.framework_files:
    print(file)
```

The output would look something like the following (Which does not display any relevant information about the object) 
```
<sparsezoo.objects.file.File object at 0x7f85dcbea370>
```

This PR adds a `__repr__` method to the `sparsezoo.objects.base.BaseObject` class, now on running the same code, we get:

```
File(folder_name=16fe8358-2e91-4b81-a1f2-df85bd1a9ac3/pytorch, override_parent_path=None, created=2021-09-14T14:04:22, modified=2021-09-14T14:04:22, model_metadata=ModelMetadata(domain=cv, sub_domain=detection, architecture=yolo_v3, sub_architecture=spp, framework=pytorch, repo=ultralytics, dataset=coco, training_scheme=None, sparse_name=base, sparse_category=none, sparse_target=None, release_version=0.7.0, created=2021-02-01T23:41:44, modified=2021-09-14T14:04:46, model_id=16fe8358-2e91-4b81-a1f2-df85bd1a9ac3, base_model=None, user_id=58e4d260-2dbc-11eb-9fc1-121789403871), file_id=28d8ff33-cd71-4230-8182-3558d587fe20, display_name=model.pth, file_type=framework, operator_version=None, checkpoint=False, md5=348305781a927460892af18dad009b7f, file_size=126342273, downloads=177, url=https://models.neuralmagic.com/cv-detection/yolo_v3-spp/pytorch-ultralytics/coco/base-none/model.pth?versionId=2jcLiQRbr7DFUwOdfU6rI4YIPK.N9ox4&Expires=1642050317&Signature=ByvUYe4MQQAa16hHF87SVreLJ7VNqt07HrS0b~HVoMf7lJgdzeVYO~FSCSbDDA8Hqy8qXY4IDA8nhgJojU-7BMkA3-4WMAb~DjrBBSUx0Poaq78jvA0lVdj4dDprvtkRgpr-h5mfX21Ln8GK6VBcHhRCLajLAFYSwe0w9zr-lO2fC7hVvythSHlq~yhZOkZvyctTKSqozSqLMQfUv2K6W89d7W6PpR2rDtLw3Tex0ULBjY5HMAL9DqRWyRqQsozsg9GO~LO7V0spwlMvYeM1tNp-FtR45bjJoW~TR10g9~D~8f7dC~CWXPlFutZXArpq-lJzmkWsISbxjbYR1j~CLQ__&Key-Pair-Id=APKAJOQR33F7CTFTKKJA, release_version=0.7.0)
```



