### PR TITLE
checkpoint download api

### DIFF
--- a/src/sparsezoo/models/zoo.py
+++ b/src/sparsezoo/models/zoo.py
@@ -19,7 +19,7 @@ Code for managing the search and creation of sparsezoo Model and Recipe objects
 
 from typing import List, Union
 
-from sparsezoo.objects.model import Model
+from sparsezoo.objects import Model
 from sparsezoo.objects.recipe import Recipe
 from sparsezoo.requests import ModelArgs
 
@@ -833,4 +833,45 @@ class Zoo:
             override_parent_path=override_parent_path,
             overwrite=overwrite,
             extensions=extensions,
+        )
+
+    @staticmethod
+    def get_checkpoints_folders_from_stub(
+        stub: Union[str, ModelArgs],
+    ):
+        """
+        Get all the tarballed checkpoint files
+        """
+        return Model.get_checkpoints_folders_from_stub(
+            stub=stub,
+        )
+
+    @staticmethod
+    def download_checkpoints_folders_from_stub(
+        stub: Union[str, ModelArgs],
+        override_folder_name: Union[str, None] = None,
+        override_parent_path: Union[str, None] = None,
+        force_token_refresh: bool = False,
+        overwrite: bool = False,
+        download_folders: Union[List[str], str] = None,
+    ):
+        """
+        Download tarballed checkpoints files.
+
+        :param stub: a string model stub that points to a SparseZoo model.
+            recipe_type may be added as a stub parameter or path of path. i.e.
+            "model/stub/path", "zoo:model/stub/path",
+            "zoo:model/stub/path?recipe_type=transfer",
+            "zoo:model/stub/path/transfer"
+        :param download_file_name: name of the file user wish to download
+        :param donwload_all: Option to download all checkpoint files
+        """
+
+        return Model.download_checkpoints_folders_from_stub(
+            stub=stub,
+            override_folder_name=override_folder_name,
+            override_parent_path=override_parent_path,
+            force_token_refresh=force_token_refresh,
+            overwrite=overwrite,
+            download_folders=download_folders,
         )

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -45,6 +45,7 @@ class FileTypes(Enum):
     ONNX_GZ = "onnx_gz"
     RECIPE = "recipe"
     FRAMEWORK = "framework"
+    CHECKPOINTS = "checkpoints"
     DATA_ORIGINALS = "originals"
     DATA_INPUTS = "inputs"
     DATA_OUTPUTS = "outputs"

--- a/src/sparsezoo/objects/model.py
+++ b/src/sparsezoo/objects/model.py
@@ -548,14 +548,12 @@ class Model(Downloadable, ModelMetadata):
         model = Model(
             **response_json["model"],
         )
-        return (
-            [
-                checkpoints_file["display_name"]
-                for checkpoints_file in model.checkpoints_folders
-            ]
-            if model.checkpoints_folders
-            else None
-        )
+        ckpt_files = []
+        if model.checkpoints_folders:
+            for checkpoints_file in model.checkpoints_folders:
+                ckpt_file_metadata = checkpoints_file.dict()
+                ckpt_files.append(ckpt_file_metadata["display_name"])
+        return ckpt_files
 
     @staticmethod
     def search_models(

--- a/src/sparsezoo/objects/model.py
+++ b/src/sparsezoo/objects/model.py
@@ -511,7 +511,10 @@ class Model(Downloadable, ModelMetadata):
 
         if isinstance(stub, str):
             stub, _ = parse_zoo_stub(stub, valid_params=[])
-        _LOGGER.debug(f"download_model_from_stub: downloading model from stub {stub}")
+        _LOGGER.debug(
+            "download_checkpoints_folders_from_stub: "
+            f"searching for model withs stub: {stub}"
+        )
         response_json = download_model_get_request(
             args=stub,
             file_name=None,
@@ -539,7 +542,9 @@ class Model(Downloadable, ModelMetadata):
         """
         if isinstance(stub, str):
             stub, _ = parse_zoo_stub(stub, valid_params=[])
-        _LOGGER.debug(f"download_model_from_stub: downloading model from stub {stub}")
+        _LOGGER.debug(
+            f"get_checkpoints_folders_from_stub: searching for model withs stub: {stub}"
+        )
         response_json = download_model_get_request(
             args=stub,
             file_name=None,
@@ -547,6 +552,9 @@ class Model(Downloadable, ModelMetadata):
         )
         model = Model(
             **response_json["model"],
+        )
+        _LOGGER.debug(
+            "get_checkpoints_folders_from_stub: Searching for checkpoint files"
         )
         ckpt_files = []
         if model.checkpoints_folders:
@@ -997,6 +1005,10 @@ class Model(Downloadable, ModelMetadata):
                 }
 
                 for download_folder in download_folders:
+                    _LOGGER.debug(
+                        f"download_checkpoints_folders: downloading {download_folder}"
+                    )
+
                     if download_folder in sorted_checkpoint_folders:
 
                         folder = sorted_checkpoint_folders[download_folder]
@@ -1010,6 +1022,9 @@ class Model(Downloadable, ModelMetadata):
             # download all checkpoints folders
             else:
                 for folder in self.checkpoints_folders:
+                    _LOGGER.debug(
+                        f"download_checkpoints_folders: downloading {download_folder}"
+                    )
                     folder.download(
                         overwrite=overwrite,
                         refresh_token=refresh_token,

--- a/src/sparsezoo/objects/model.py
+++ b/src/sparsezoo/objects/model.py
@@ -168,7 +168,6 @@ class Model(Downloadable, ModelMetadata):
             [
                 File(
                     model_metadata=metadata,
-                    # child_folder_name=metadata.checkpoints,
                     override_folder_name=override_folder_name,
                     override_parent_path=override_parent_path,
                     **res,
@@ -176,7 +175,7 @@ class Model(Downloadable, ModelMetadata):
                 for res in sorted_files[FileTypes.CHECKPOINTS.value]
             ]
             if sorted_files[FileTypes.CHECKPOINTS.value]
-            else None
+            else []
         )
 
         self._onnx_files = (
@@ -978,26 +977,31 @@ class Model(Downloadable, ModelMetadata):
         overwrite: bool = False,
         refresh_token: bool = False,
         show_progress: bool = True,
-        extensions: Union[List[str], None] = None,
     ):
+        """
+        Download the given checkpoints folder if it exists. If not given, download all.
+        User can check which folders exist with
+            Zoo.get_checkpoints_folders_from_stub(stub)
+
+        """
 
         if self.checkpoints_folders:
             downloaded_paths = []
+
             if download_folders:
                 if isinstance(download_folders, str):
                     download_folders = [download_folders]
 
+                # enable class File to be extracted via folder name
                 sorted_checkpoint_folders = {
                     checkpoints_folder.display_name: checkpoints_folder
                     for checkpoints_folder in self.checkpoints_folders
                 }
+
                 for download_folder in download_folders:
                     if download_folder in sorted_checkpoint_folders:
+
                         folder = sorted_checkpoint_folders[download_folder]
-                        if extensions and not any(
-                            folder.display_name.endswith(ext) for ext in extensions
-                        ):  # skip files that do not end in valid extension
-                            continue
                         folder.download(
                             overwrite=overwrite,
                             refresh_token=refresh_token,
@@ -1005,12 +1009,9 @@ class Model(Downloadable, ModelMetadata):
                         )
                         downloaded_paths.append(folder.path)
 
+            # download all checkpoints folders
             else:
                 for folder in self.checkpoints_folders:
-                    if extensions and not any(
-                        folder.display_name.endswith(ext) for ext in extensions
-                    ):  # skip files that do not end in valid extension
-                        continue
                     folder.download(
                         overwrite=overwrite,
                         refresh_token=refresh_token,
@@ -1020,24 +1021,6 @@ class Model(Downloadable, ModelMetadata):
             return downloaded_paths
 
         return None
-
-        # for file in self._framework_files:
-        #     if extensions and not any(
-        #         file.display_name.endswith(ext) for ext in extensions
-        #     ):  # skip files that do not end in valid extension
-        #         continue
-
-        #     _LOGGER.info(
-        #         f"Downloading model framework file {file.display_name} {self.stub}"
-        #     )
-        #     file.download(
-        #         overwrite=overwrite,
-        #         refresh_token=refresh_token,
-        #         show_progress=show_progress,
-        #     )
-        #     downloaded_paths.append(file.path)
-        # return downloaded_paths
-        # pass
 
     def search_similar_models(
         self,


### PR DESCRIPTION
Blocked on https://github.com/neuralmagic/zoomodels/pull/146

Added:
- [X] Show all checkpoints folders 
- [X] Download checkpoints .tar.gz folders with stub 

```python3
from sparsezoo.models import Zoo

stub = "zoo:test_nlp/masked_language_modeling/bert-base/pytorch/huggingface/wikipedia_bookcorpus/base-none"

print(Zoo.get_checkpoints_folders_from_stub(stub)) # show all checkpoints folders
Zoo.download_checkpoints_folders_from_stub(stub) # download all checkpoint folders
Zoo.download_checkpoints_folders_from_stub(
    stub=stub, 
    download_folders=[
            "checkpoints_epoch10.tar.gz",
            "checkpoints_epoch20.tar.gz",
        ]
    ) # download only the specific folders if they exist
```




