### PR TITLE
Update: Supported Python versions

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Developing SparseZoo
 
-SparseZoo is developed and tested using Python 3.6+.
+SparseZoo is developed and tested using Python 3.6-3.9.
 To develop sparsezoo, you will also need the development dependencies and to follow the styling guidelines.
 
 Here's some details to get started.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The [GitHub repository](https://github.com/neuralmagic/sparsezoo) contains the P
 
 ## Installation
 
-This repository is tested on Python 3.6+, and Linux/Debian systems.
+This repository is tested on Python 3.6-3.9, and Linux/Debian systems.
 It is recommended to install in a [virtual environment](https://docs.python.org/3/library/venv.html) to keep your system in order.
 
 Install with pip using:


### PR DESCRIPTION
The goal of this PR is to make supported Python versions explicit in all our docs

* `Python 3.6+` --> `Python 3.6-3.9`