### PR TITLE
[Hotfix] Expose function `load_numpy_from_tar` 

### DIFF
--- a/src/sparsezoo/utils/numpy.py
+++ b/src/sparsezoo/utils/numpy.py
@@ -34,6 +34,7 @@ __all__ = [
     "load_numpy",
     "save_numpy",
     "load_numpy_list",
+    "load_numpy_from_tar",
     "NumpyArrayBatcher",
     "tensor_export",
     "tensors_export",


### PR DESCRIPTION
Current blocker to my SparseML PR: https://github.com/neuralmagic/sparseml/pull/632