### PR TITLE
Revert "initial commit (#141)"

### DIFF
--- a/src/sparsezoo/utils/numpy.py
+++ b/src/sparsezoo/utils/numpy.py
@@ -34,7 +34,6 @@ __all__ = [
     "load_numpy",
     "save_numpy",
     "load_numpy_list",
-    "load_numpy_from_tar",
     "NumpyArrayBatcher",
     "tensor_export",
     "tensors_export",


### PR DESCRIPTION
This reverts commit f8b31b7a80aae4dbb28578a306c614e4b3277eca. 

Realized post-mortem, that this commit:

https://github.com/neuralmagic/sparsezoo/commit/f8b31b7a80aae4dbb28578a306c614e4b3277eca

is not only erroneously named ("initial commit") but also redundant. One should call `"load_numpy_from_tar"` through `"load_numpy_list"`, which had been already exposed for imports.