### PR TITLE
Makefile uses python, so DEVELOPING and docs should too

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -28,7 +28,7 @@ Here's some details to get started.
 ```bash
 git clone https://github.com/neuralmagic/sparsezoo.git
 cd sparsezoo
-python3 -m pip install -e ./[dev]
+python -m pip install -e ./[dev]
 ```
 
 This will clone the SparseZoo repo, install it, and install the development dependencies.

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ docsupdate:
 # creates wheel file
 build:
 	@echo "Building python package";
-	python3 setup.py sdist bdist_wheel $(BUILD_ARGS)
+	python setup.py sdist bdist_wheel $(BUILD_ARGS)
 
 # clean package
 clean:

--- a/scripts/sparsezoo_script.py
+++ b/scripts/sparsezoo_script.py
@@ -144,12 +144,12 @@ optional arguments:
 
 ##########
 Example search:
-python3 scripts/sparsezoo.py search --domain cv --sub-domain classification
+python scripts/sparsezoo.py search --domain cv --sub-domain classification
 
 
 ##########
 Example search for MobileNetV1:
-python3 scripts/sparsezoo.py search --domain cv --sub-domain classification \
+python scripts/sparsezoo.py search --domain cv --sub-domain classification \
     --architecture mobilenet_v1
 
 

--- a/src/sparsezoo/main.py
+++ b/src/sparsezoo/main.py
@@ -144,12 +144,12 @@ optional arguments:
 
 ##########
 Example search:
-python3 scripts/main.py search --domain cv --sub-domain classification
+python scripts/main.py search --domain cv --sub-domain classification
 
 
 ##########
 Example search for MobileNetV1:
-python3 scripts/main.py search --domain cv --sub-domain classification \
+python scripts/main.py search --domain cv --sub-domain classification \
     --architecture mobilenet_v1
 
 


### PR DESCRIPTION
The `DEVELOPING` doc suggests installing dependencies using `python3`, however the `Makefile` doesn't follow this pattern and instead invokes `python` directly. This is kind of lame because it means that the developing workflow breaks as soon as you try to run `make style` or `make quality`. Since invoking `python` as `python3` is an ubuntu (debian?) concern, I propose that `DEVELOPING` should also just use `python` instead of `python3`. I think this can help a few things:

- More consistent
- More OS agnostic
- Helps avoid weirdness where `python` and `python3` are not the same python which leads to strange `make` failures that may not be the easiest to diagnose. A user could still run into problems if `python` refers to python 2, but at least that should be a more consistent issue to diagnose and correct and such an error would occur when trying to install dependencies instead of being masked by `make`

I also updated comments that refer to `python3`.

The `DEVELOPING` doc doesn't really seem like the right place, but the `python-is-python3` apt package makes `python` invoke `python3` and perhaps that could be mentioned somewhere. I guess I'm kind of inclined to leave it to the user to make sense of their python setup and we should just refer to `python`.