### PR TITLE
[CI-CD Refactor] Fix onnruntime and deepsparse output validation bug

### DIFF
--- a/src/sparsezoo/v2/__init__.py
+++ b/src/sparsezoo/v2/__init__.py
@@ -16,5 +16,6 @@
 
 from .directory import *
 from .file import *
+from .inference_runner import *
 from .model_directory import *
 from .model_objects import *

--- a/src/sparsezoo/v2/inference_runner.py
+++ b/src/sparsezoo/v2/inference_runner.py
@@ -145,7 +145,7 @@ class InferenceRunner:
         try:
             import deepsparse  # noqa F401
         except ModuleNotFoundError as e:  # noqa F841
-            pass
+            raise e
 
         from deepsparse import compile_model
 

--- a/src/sparsezoo/v2/inference_runner.py
+++ b/src/sparsezoo/v2/inference_runner.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from collections import OrderedDict
+from typing import List, Tuple
+
+import numpy as np
+import onnx
+
+import onnxruntime as ort
+from sparsezoo.utils.numpy import save_numpy
+from sparsezoo.v2.file import File
+from sparsezoo.v2.model_objects import NumpyDirectory
+
+
+__all__ = ["InferenceRunner"]
+
+
+class InferenceRunner:
+    """
+    Helper class for running inference
+    given `sample_inputs`, `sample_outputs` and the onnx model.
+
+    This is intended to be used by the ModelDirectory class object.
+
+    :params sample_inputs: File object containing sample inputs to the inference engine
+    :params sample_outputs: File object containing sample outputs the inference engine
+    :params onnx_model: File object holding the onnx model
+    :params supported_engines: List of the names of supported engines
+        (e.g. torch, keras, deepsparse etc.)
+    """
+
+    def __init__(
+        self,
+        sample_inputs: NumpyDirectory,
+        sample_outputs: NumpyDirectory,
+        onnx_file: File,
+        supported_engines: List[str],
+    ):
+        self.sample_inputs = sample_inputs
+        self.sample_outputs = sample_outputs
+        self.onnx_file = onnx_file
+        self.supported_engines = supported_engines
+
+        self.engine_type_to_iterator = {
+            "onnxruntime": self._run_with_onnx_runtime,
+            "deepsparse": self._run_with_deepsparse,
+        }
+
+    def generate_outputs(
+        self, engine_type: str, save_to_tar: bool
+    ) -> Tuple[List[np.ndarray]]:
+        """
+        Chooses the appropriate engine type to load the onnx model
+        Then, feeds the data (sample inputs)
+        to generate model outputs (in the iterative fashion).
+
+        This is a general method to obtain `sample_outputs` from
+        `sample_inputs`, given the inference engine.
+
+        :params engine_type: name of the inference engine
+        :params save_to_tar: boolean flag; if True, the output generated
+            by the engine from `sample_inputs` directory will be saved to
+            the archive file `sample_outputs_{engine_type}.tar.gz
+            (located in the same folder as `sample_inputs`).
+            If False, the function will yield model outputs in the
+            iterative fashion (one per input)
+        :returns Sequentially return a tuple of list
+            containing numpy arrays, representing the output
+            from the inference engine
+        """
+        if engine_type not in self.supported_engines:
+            raise ValueError(
+                f"The argument `engine_type` must be one of {self.supported_engines}"
+            )
+
+        iterator = self.engine_type_to_iterator[engine_type]
+
+        # pre-compute the generator, to optionally to use it for
+        # saving to tar
+        outputs = (x for x in iterator())
+
+        if save_to_tar:
+            output_files = []
+
+            path = os.path.join(
+                os.path.dirname(self.sample_inputs.path),
+                f"sample_outputs_{engine_type}",
+            )
+            if not os.path.exists(path):
+                os.mkdir(path)
+
+            for input, output in zip(self.sample_inputs.files, outputs):
+                # if input's name is `inp-XXXX.npz`
+                # output's name should be `out-XXXX.npz`
+                name = input.name.replace("inp", "out")
+                # we need to remove `.npz`, this is
+                # required by save_numpy() function
+                save_numpy(
+                    array=output, export_dir=path, name="".join(name.split(".")[:-1])
+                )
+                output_files.append(File(name=name, path=os.path.join(path, name)))
+
+            output_directory = NumpyDirectory(
+                name=os.path.basename(path), path=path, files=output_files
+            )
+            output_directory.gzip()
+
+        for output in outputs:
+            yield output
+
+    def validate_with_onnx_runtime(self) -> bool:
+        """
+        Validates that output from the onnxruntime
+        engine matches the expected output.
+
+        :params engine_type: name of the inference engine
+        :return boolean flag; if True, outputs match expected outputs. False otherwise
+        """
+        validation = []
+        for target_output, output in zip(
+            self.sample_outputs, self._run_with_onnx_runtime()
+        ):
+            target_output = list(target_output.values())
+            is_valid = [
+                np.allclose(o1, o2.flatten(), atol=1e-5)
+                for o1, o2 in zip(target_output, output)
+            ]
+            validation += is_valid
+        return all(validation)
+
+    def _run_with_deepsparse(self):
+        try:
+            import deepsparse  # noqa F401
+        except ModuleNotFoundError as e:  # noqa F841
+            pass
+
+        from deepsparse import compile_model
+
+        engine = compile_model(self.onnx_file.path, batch_size=1)
+
+        for index, input_data in enumerate(self.sample_inputs):
+            model_input = [np.expand_dims(x, 0) for x in input_data.values()]
+            output = engine.run(model_input)
+            yield output
+
+    def _run_with_onnx_runtime(self):
+
+        ort_sess = ort.InferenceSession(self.onnx_file.path)
+        model = onnx.load(self.onnx_file.path)
+        input_names = [inp.name for inp in model.graph.input]
+
+        for index, input_data in enumerate(self.sample_inputs):
+            model_input = OrderedDict(
+                [
+                    (k, np.expand_dims(v, 0))
+                    for k, v in zip(input_names, input_data.values())
+                ]
+            )
+            output = ort_sess.run(None, model_input)
+            yield output

--- a/src/sparsezoo/v2/model_directory.py
+++ b/src/sparsezoo/v2/model_directory.py
@@ -40,10 +40,9 @@ def file_dictionary(**kwargs):
 
 
 class InferenceRunner:
-    # TODO: Turn sample_outputs into Dict[str, NumpyDirectory]
     """
     Helper class for running inference
-    given sample_inputs, sample_outputs and onnx model.
+    given `sample_inputs`, `sample_outputs` and the onnx model.
 
     :params sample_inputs: File object containing sample inputs to the inference engine
     :params sample_outputs: File object containing sample outputs the inference engine
@@ -85,7 +84,7 @@ class InferenceRunner:
         Validates that output from the engine matches the expected output
 
         :params engine_type: name of the inference engine
-        :return bolean flag; if True, outputs match expected outputs. False otherwise
+        :return boolean flag; if True, outputs match expected outputs. False otherwise
         """
         validation = []
         for target_output, output in zip(

--- a/src/sparsezoo/v2/model_directory.py
+++ b/src/sparsezoo/v2/model_directory.py
@@ -18,12 +18,13 @@ import os
 import re
 import typing
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import onnx
 
 import onnxruntime as ort
+from sparsezoo.utils.numpy import save_numpy
 from sparsezoo.v2.directory import Directory
 from sparsezoo.v2.file import File
 from sparsezoo.v2.model_objects import FrameworkFiles, NumpyDirectory, SampleOriginals
@@ -59,25 +60,67 @@ class InferenceRunner:
         self.sample_outputs = sample_outputs
         self.onnx_file = onnx_file
 
+        self.engine_type_to_iterator = {
+            "onnxruntime": self._run_with_onnx_runtime,
+            "deepsparse": self._run_with_deepsparse,
+        }
+
     def generate_outputs(
-        self, engine_type: str
-    ) -> Union[List[np.ndarray], typing.OrderedDict[str, np.ndarray]]:
+        self, engine_type: str, save_to_tar: bool
+    ) -> Tuple[List[np.ndarray]]:
         """
         Chooses the appropriate engine type to load the onnx model
         Then, feeds the data (sample inputs)
         to generate model outputs (in the iterative fashion)
 
         :params engine_type: name of the inference engine
-        :returns engine output
+        :params save_to_tar: boolean flag; if True, the output generated
+            by the engine from `sample_inputs` directory will be saved to
+            the archive file `sample_outputs_{engine_type}.tar.gz
+            (located in the same folder as `sample_inputs`).
+            If False, the function will yield model outputs in the
+            iterative fashion (one per input)
+        :returns Sequentially return a tuple of list
+            containing numpy arrays, representing the output
+            from the inference engine
         """
         if engine_type not in ENGINES:
             raise ValueError(f"The argument `engine_type` must be one of {ENGINES}")
-        elif engine_type == "onnxruntime":
-            for output in self._run_with_onnx_runtime():
-                yield output
-        else:
-            for output in self._run_with_deepsparse():
-                yield output
+
+        iterator = self.engine_type_to_iterator[engine_type]
+
+        # pre-compute the generator, to optionally to use it for
+        # saving to tar
+        outputs = (x for x in iterator())
+
+        if save_to_tar:
+            output_files = []
+
+            path = os.path.join(
+                os.path.dirname(self.sample_inputs.path),
+                f"sample_outputs_{engine_type}",
+            )
+            if not os.path.exists(path):
+                os.mkdir(path)
+
+            for input, output in zip(self.sample_inputs.files, outputs):
+                # if input's name is `inp-XXXX.npz`
+                # output's name should be `out-XXXX.npz`
+                name = input.name.replace("inp", "out")
+                # we need to remove `.npz`, this is
+                # required by save_numpy() function
+                save_numpy(
+                    array=output, export_dir=path, name="".join(name.split(".")[:-1])
+                )
+                output_files.append(File(name=name, path=os.path.join(path, name)))
+
+            output_directory = NumpyDirectory(
+                name=os.path.basename(path), path=path, files=output_files
+            )
+            output_directory.gzip()
+
+        for output in outputs:
+            yield output
 
     def validate_with_onnx_runtime(self) -> bool:
         """
@@ -265,17 +308,26 @@ class ModelDirectory(Directory):
         return ModelDirectory(files=files, name="model_directory", path=directory_path)
 
     def generate_outputs(
-        self, engine_type: str = "onnxruntime"
-    ) -> Union[List[np.ndarray], typing.OrderedDict[str, np.ndarray]]:
+        self, engine_type: str, save_to_tar: bool = False
+    ) -> Union[List[np.ndarray], typing.OrderedDict[str, np.ndarray], None]:
         """
         Chooses the appropriate engine type to obtain inference outputs
-        from the `InferenceRunner` class object.
+        from the `InferenceRunner` class object. The function yields model
+        outputs sequentially (in the iterative fashion)
 
         :params engine_type: name of the inference engine
-        :returns engine output. The outputs are yielded
-            in iterative fashion.
+        :params save_to_tar: boolean flag; if True, the output generated
+            by the `inference_runner` will be additionally saved to
+            the archive file `sample_outputs_{engine_type}.tar.gz
+            (located in the `self.path` directory).
+        :returns returns a data structure
+            containing numpy arrays, representing the output
+            from the inference engine
         """
-        for output in self.inference_runner.generate_outputs(engine_type=engine_type):
+
+        for output in self.inference_runner.generate_outputs(
+            engine_type=engine_type, save_to_tar=save_to_tar
+        ):
             yield output
 
     def download(self, directory_path: str, override: bool = False) -> bool:

--- a/src/sparsezoo/v2/model_directory.py
+++ b/src/sparsezoo/v2/model_directory.py
@@ -50,7 +50,12 @@ class InferenceRunner:
     :params onnx_model: File object holding the onnx model
     """
 
-    def __init__(self, sample_inputs: NumpyDirectory, sample_outputs: NumpyDirectory, onnx_file: File):
+    def __init__(
+        self,
+        sample_inputs: NumpyDirectory,
+        sample_outputs: NumpyDirectory,
+        onnx_file: File,
+    ):
         self.sample_inputs = sample_inputs
         self.sample_outputs = sample_outputs
         self.onnx_file = onnx_file
@@ -219,7 +224,9 @@ class ModelDirectory(Directory):
         ]
 
         self.inference_runner = InferenceRunner(
-            sample_inputs=self.sample_inputs, sample_outputs=self.sample_outputs, onnx_file=self.onnx_model
+            sample_inputs=self.sample_inputs,
+            sample_outputs=self.sample_outputs,
+            onnx_file=self.onnx_model,
         )
 
         super().__init__(files=files, name=name, path=path, url=url)
@@ -269,9 +276,7 @@ class ModelDirectory(Directory):
         :returns engine output. The outputs are yielded
             in iterative fashion.
         """
-        for output in self.inference_runner.generate_outputs(
-            engine_type=engine_type
-        ):
+        for output in self.inference_runner.generate_outputs(engine_type=engine_type):
             yield output
 
     def download(self, directory_path: str, override: bool = False) -> bool:
@@ -306,8 +311,7 @@ class ModelDirectory(Directory):
         return: a boolean flag; if True, the validation has been successful
         """
 
-        if not self.inference_runner.validate_with_onnx_runtime(
-        ):
+        if not self.inference_runner.validate_with_onnx_runtime():
             logging.warning(
                 "Failed to validate the compatibility of "
                 "`sample_inputs` files with the `model.onnx` model."

--- a/tests/sparsezoo/v2/test_model_directory.py
+++ b/tests/sparsezoo/v2/test_model_directory.py
@@ -119,26 +119,49 @@ class TestModelDirectory:
 
     def test_generate_outputs_onnxruntime(self, setup):
         directory_path, request_json, expected_content, temp_dir = setup
-
         model_directory = ModelDirectory.from_directory(directory_path=directory_path)
+
+        # test whether the functionality saves the numpy files to tar properly
+        tar_file_expected_path = os.path.join(
+            directory_path, "sample_outputs_onnxruntime.tar.gz"
+        )
+        if os.path.isfile(tar_file_expected_path):
+            os.remove(tar_file_expected_path)
+
         for output_expected, output in zip(
             model_directory.sample_outputs,
-            model_directory.generate_outputs(engine_type="onnxruntime"),
+            model_directory.generate_outputs(
+                engine_type="onnxruntime", save_to_tar=True
+            ),
         ):
             output_expected = list(output_expected.values())
             for o1, o2 in zip(output_expected, output):
                 assert pytest.approx(o1, abs=1e-5) == o2.flatten()
+
+        assert os.path.isfile(tar_file_expected_path)
 
     def test_generate_outputs_deepsparse(self, setup):
         directory_path, request_json, expected_content, temp_dir = setup
         model_directory = ModelDirectory.from_directory(directory_path=directory_path)
+
+        # test whether the functionality saves the numpy files to tar properly
+        tar_file_expected_path = os.path.join(
+            directory_path, "sample_outputs_deepsparse.tar.gz"
+        )
+        if os.path.isfile(tar_file_expected_path):
+            os.remove(tar_file_expected_path)
+
         for output_expected, output in zip(
             model_directory.sample_outputs,
-            model_directory.generate_outputs(engine_type="deepsparse"),
+            model_directory.generate_outputs(
+                engine_type="deepsparse", save_to_tar=True
+            ),
         ):
             output_expected = list(output_expected.values())
             for o1, o2 in zip(output_expected, output):
                 assert pytest.approx(o1, abs=1e-5) == o2.flatten()
+
+        assert os.path.isfile(tar_file_expected_path)
 
     def test_analysis(self, setup):
         pass

--- a/tests/sparsezoo/v2/test_model_directory.py
+++ b/tests/sparsezoo/v2/test_model_directory.py
@@ -127,7 +127,7 @@ class TestModelDirectory:
         ):
             output_expected = list(output_expected.values())
             for o1, o2 in zip(output_expected, output):
-                pytest.approx(o1, abs=1e-5) == o2.flatten()
+                assert pytest.approx(o1, abs=1e-5) == o2.flatten()
 
     def test_generate_outputs_deepsparse(self, setup):
         directory_path, request_json, expected_content, temp_dir = setup
@@ -138,7 +138,7 @@ class TestModelDirectory:
         ):
             output_expected = list(output_expected.values())
             for o1, o2 in zip(output_expected, output):
-                pytest.approx(o1, abs=1e-5) == o2.flatten()
+                assert pytest.approx(o1, abs=1e-5) == o2.flatten()
 
     def test_analysis(self, setup):
         pass


### PR DESCRIPTION
The `input_samples.files` and `output_samples.files` lists, by default, were not in-sync e.g.
`input_samples.files -> ['inp-004.npz', 'inp-016.npz', 'inp-006.npz' ...]`
`output_samples.files -> ['out-003npz', 'out-006.npz', 'out-007.npz' ...]`

This was leading to errors when iterating over `zip(input_samples, output_samples)` due to unmatching expected outputs and actual outputs. Sorting the numpy files solves the problem.

Also, the big feature of this PR is to refactor the code so that `InferenceRunner` is a stand-alone class and not a functionality buried within `ModelDirectory`