### PR TITLE
[CI-CD Refactor] Validation of model cards/recipes 

### DIFF
--- a/src/sparsezoo/v2/file.py
+++ b/src/sparsezoo/v2/file.py
@@ -216,6 +216,9 @@ class File:
             result = regex.search(yaml_str)
             yaml_str = result.group(1)
             yaml_dict = yaml.safe_load(yaml_str)
+            # returns a string "{domain}-{sub_domain}, if valid
+            # this makes the method reusable to fetch the integration
+            # name for the integration validation
             return f"{yaml_dict['domain']}-{yaml_dict['sub_domain']}"
 
         except Exception as error:  # noqa: F841

--- a/src/sparsezoo/v2/file.py
+++ b/src/sparsezoo/v2/file.py
@@ -219,7 +219,7 @@ class File:
             # returns a string "{domain}-{sub_domain}, if valid
             # this makes the method reusable to fetch the integration
             # name for the integration validation
-            return f"{yaml_dict['domain']}-{yaml_dict['sub_domain']}"
+            return yaml_dict
 
         except Exception as error:  # noqa: F841
             logging.error(error)

--- a/src/sparsezoo/v2/file.py
+++ b/src/sparsezoo/v2/file.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import os
+import re
 import time
 import traceback
 from typing import Any, Dict, Optional
@@ -186,15 +187,50 @@ class File:
                 strict_mode=strict_mode,
             )
 
-    def _validate_markdown(self, strict_mode):
+    def _validate_recipe(self, strict_mode):
+        from sparseml.pytorch.optim import ScheduledModifierManager
+
         try:
-            with open(self.path) as file:
-                file.readlines()
+            manager = ScheduledModifierManager.from_yaml(self.path)  # noqa  F841
         except Exception as error:  # noqa: F841
             self._throw_error(
                 error_msg="Markdown file could not been loaded properly",
                 strict_mode=strict_mode,
             )
+
+    def _validate_model_card(self):
+        try:
+            with open(self.path, "r") as yaml_file:
+                yaml_str = yaml_file.read()
+
+            # extract YAML front matter from markdown recipe card
+            # adapted from
+            # https://github.com/jonbeebe/frontmatter/blob/master/frontmatter
+            yaml_delim = r"(?:---|\+\+\+)"
+            _yaml = r"(.*?)"
+            re_pattern = r"^\s*" + yaml_delim + _yaml + yaml_delim
+            regex = re.compile(re_pattern, re.S | re.M)
+            result = regex.search(yaml_str)
+            yaml_str = result.group(1)
+            yaml_dict = yaml.safe_load(yaml_str)
+            return f"{yaml_dict['domain']}-{yaml_dict['sub_domain']}"
+
+        except Exception as error:  # noqa: F841
+            logging.error(error)
+
+    def _validate_markdown(self, strict_mode):
+        # test if .md file is a model_card
+        is_valid_model_card = self._validate_model_card()
+        # if not, attempt to check if it is a recipe file
+        if not is_valid_model_card:
+            try:
+                from sparseml.pytorch.optim import (  # noqa  F401
+                    ScheduledModifierManager,
+                )
+            except Exception as error:  # noqa  F841
+                # if not model card and unable to check if recipe, assume correct
+                return
+            self._validate_recipe(strict_mode=strict_mode)
 
     def _validate_json(self, strict_mode):
         try:

--- a/src/sparsezoo/v2/file.py
+++ b/src/sparsezoo/v2/file.py
@@ -188,6 +188,9 @@ class File:
             )
 
     def _validate_recipe(self, strict_mode):
+        # only validate whether a file is a recipe if sparseml is installed.
+        # this is optional, since we do not want to have an explicit dependency
+        # on sparseml in sparsezoo.
         from sparseml.pytorch.optim import ScheduledModifierManager
 
         try:
@@ -228,7 +231,8 @@ class File:
                     ScheduledModifierManager,
                 )
             except Exception as error:  # noqa  F841
-                # if not model card and unable to check if recipe, assume correct
+                # if not model card and unable to check if recipe,
+                # optimistically assume the .md file is valid.
                 return
             self._validate_recipe(strict_mode=strict_mode)
 

--- a/tests/sparsezoo/v2/test_file.py
+++ b/tests/sparsezoo/v2/test_file.py
@@ -28,6 +28,17 @@ from sparsezoo.utils.numpy import save_numpy
 from sparsezoo.v2.file import File
 
 
+MODEL_CARD = """
+---
+domain: "nlp"
+sub_domain: "question_answering"
+architecture: "bert"
+sub_architecture: "base"
+framework: "pytorch"
+---
+"""
+
+
 def _create_yaml_file(file_path):
     test_dict = {"test_key": "test_value"}
     with open(file_path, "w") as outfile:
@@ -64,9 +75,8 @@ def _create_onnx_file(file_path):
 
 
 def _create_md_file(file_path):
-    test_string = "test_string"
     with open(file_path, "w") as outfile:
-        outfile.write(test_string)
+        outfile.write(MODEL_CARD)
 
 
 def _create_json_file(file_path):
@@ -82,7 +92,9 @@ def _create_image_file(file_path):
 
 
 def _create_csv_file(file_path):
-    _create_md_file(file_path)
+    test_string = "test_string"
+    with open(file_path, "w") as outfile:
+        outfile.write(test_string)
 
 
 def _create_sample_file(file_path):


### PR DESCRIPTION
Enable `File` class object to parse `.md` files (either model cards or recipes).
Note, that validation of recipes is optional. This is because to validate a recipe, we need to use tools present in SparseML, and we want to avoid explicit dependency on the library.