### PR TITLE
[CI-CD Refactor] Sample-outputs now Dict[str, NumpyDirectory] instead of NumpyDirectory

### DIFF
--- a/src/sparsezoo/v2/model_directory.py
+++ b/src/sparsezoo/v2/model_directory.py
@@ -552,7 +552,11 @@ class ModelDirectory(Directory):
         for directory in directories:
             engine_name = directory.name.split("_")[-1]
             if engine_name not in ENGINES:
-                raise ValueError("")
+                raise ValueError(
+                    f"The name of the 'sample_outputs' directory should "
+                    f"end with an engine name (one of the {ENGINES}). "
+                    f"However, the name is {directory.name}."
+                )
             engine_to_numpydir_map[engine_name] = directory
         return engine_to_numpydir_map
 

--- a/src/sparsezoo/v2/model_directory.py
+++ b/src/sparsezoo/v2/model_directory.py
@@ -50,7 +50,12 @@ class InferenceRunner:
     :params onnx_model: File object holding the onnx model
     """
 
-    def __init__(self, sample_inputs: NumpyDirectory, sample_outputs: NumpyDirectory, onnx_file: File):
+    def __init__(
+        self,
+        sample_inputs: NumpyDirectory,
+        sample_outputs: NumpyDirectory,
+        onnx_file: File,
+    ):
         self.sample_inputs = sample_inputs
         self.sample_outputs = sample_outputs
         self.onnx_file = onnx_file
@@ -219,7 +224,9 @@ class ModelDirectory(Directory):
         ]
 
         self.inference_runner = InferenceRunner(
-            sample_inputs=self.sample_inputs, sample_outputs=self.sample_outputs, onnx_file=self.onnx_model
+            sample_inputs=self.sample_inputs,
+            sample_outputs=self.sample_outputs,
+            onnx_file=self.onnx_model,
         )
 
         super().__init__(files=files, name=name, path=path, url=url)
@@ -269,9 +276,7 @@ class ModelDirectory(Directory):
         :returns engine output. The outputs are yielded
             in iterative fashion.
         """
-        for output in self.inference_runner.generate_outputs(
-            engine_type=engine_type
-        ):
+        for output in self.inference_runner.generate_outputs(engine_type=engine_type):
             yield output
 
     def download(self, directory_path: str, override: bool = False) -> bool:
@@ -306,8 +311,7 @@ class ModelDirectory(Directory):
         return: a boolean flag; if True, the validation has been successful
         """
 
-        if not self.inference_runner.validate_with_onnx_runtime(
-        ):
+        if not self.inference_runner.validate_with_onnx_runtime():
             logging.warning(
                 "Failed to validate the compatibility of "
                 "`sample_inputs` files with the `model.onnx` model."

--- a/src/sparsezoo/v2/model_directory.py
+++ b/src/sparsezoo/v2/model_directory.py
@@ -31,7 +31,7 @@ from sparsezoo.v2.model_objects import FrameworkFiles, NumpyDirectory, SampleOri
 
 __all__ = ["ModelDirectory"]
 
-ENGINES = ["onnxruntime", "deepsparse", "pytorch", "keras", "tensorflow_v1"]
+ENGINES = ["onnxruntime", "deepsparse", "torch", "keras", "tensorflow_v1"]
 
 
 def file_dictionary(**kwargs):

--- a/src/sparsezoo/v2/model_directory.py
+++ b/src/sparsezoo/v2/model_directory.py
@@ -31,8 +31,7 @@ from sparsezoo.v2.model_objects import FrameworkFiles, NumpyDirectory, SampleOri
 
 __all__ = ["ModelDirectory"]
 
-FRAMEWORKS = ["pytorch", "keras", "tensorflow"]
-ENGINES = ["onnxruntime", "deepsparse"]
+ENGINES = ["onnxruntime", "deepsparse", "pytorch", "keras", "tensorflow_v1"]
 
 
 def file_dictionary(**kwargs):

--- a/tests/sparsezoo/v2/test_model_directory.py
+++ b/tests/sparsezoo/v2/test_model_directory.py
@@ -127,7 +127,7 @@ class TestModelDirectory:
         ):
             output_expected = list(output_expected.values())
             for o1, o2 in zip(output_expected, output):
-                pytest.approx(o1, abs=1e-5) == o2.flatten()
+                assert pytest.approx(o1, abs=1e-5) == o2.flatten()
 
     def test_generate_outputs_deepsparse(self, setup):
         directory_path, request_json, expected_content, temp_dir = setup
@@ -138,7 +138,7 @@ class TestModelDirectory:
         ):
             output_expected = list(output_expected.values())
             for o1, o2 in zip(output_expected, output):
-                pytest.approx(o1, abs=1e-5) == o2.flatten()
+                assert pytest.approx(o1, abs=1e-5) == o2.flatten()
 
     def test_analysis(self, setup):
         pass

--- a/tests/sparsezoo/v2/test_model_directory.py
+++ b/tests/sparsezoo/v2/test_model_directory.py
@@ -122,7 +122,7 @@ class TestModelDirectory:
 
         model_directory = ModelDirectory.from_directory(directory_path=directory_path)
         for output_expected, output in zip(
-            model_directory.sample_outputs,
+            model_directory.sample_outputs["onnxruntime"],
             model_directory.generate_outputs(engine_type="onnxruntime"),
         ):
             output_expected = list(output_expected.values())
@@ -133,12 +133,14 @@ class TestModelDirectory:
         directory_path, request_json, expected_content, temp_dir = setup
         model_directory = ModelDirectory.from_directory(directory_path=directory_path)
         for output_expected, output in zip(
-            model_directory.sample_outputs,
+            model_directory.sample_outputs["deepsparse"],
             model_directory.generate_outputs(engine_type="deepsparse"),
         ):
             output_expected = list(output_expected.values())
             for o1, o2 in zip(output_expected, output):
-                assert pytest.approx(o1, abs=1e-5) == o2.flatten()
+                assert (
+                    pytest.approx(o1, abs=1e-4) == o2.flatten()
+                )  # lower accuracy, comparing onnxruntime output with deepsparse output
 
     def test_analysis(self, setup):
         pass


### PR DESCRIPTION
Before:
we were assuming that the `ModelDirectory` contains a single `sample_output` folder.
Now:
`ModelDirectory` may contain several folders named `sample_output_{engine_name}`, which need to be handled by the API.