### PR TITLE
[cherry-pick 1.0.0] pin protobuf version for onnx compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ _PACKAGE_NAME = "sparsezoo" if is_release else "sparsezoo-nightly"
 _deps = [
     "numpy>=1.0.0",
     "onnx>=1.0.0,<=1.10.1",
+    "protobuf>=3.12.2,<4",
     "pyyaml>=5.1.0",
     "requests>=2.0.0",
     "tqdm>=4.0.0",


### PR DESCRIPTION
fixes dependencies bug affecting latest pypi release