### PR TITLE
[CI/CD Refactor] `setup_model_directory` helper function

### DIFF
--- a/src/sparsezoo/v2/helpers.py
+++ b/src/sparsezoo/v2/helpers.py
@@ -1,0 +1,76 @@
+"""
+Helper functions pertaining to the creation of ModelDirectory
+"""
+
+import copy
+from pathlib import Path
+from sparsezoo.v2 import File, Directory, NumpyDirectory, SampleOriginals
+from typing import Union, List
+import logging
+import os
+import shutil
+
+def setup_model_directory(
+        output_dir: str,
+        training: Union[str, Directory],
+        deployment: Union[str, Directory],
+        onnx_model: Union[File, str],
+        sample_inputs: Union[str, NumpyDirectory],
+        sample_outputs: Union[str, NumpyDirectory, None] = None,
+        sample_labels: Union[Directory, str, None] = None,
+        sample_originals: Union[SampleOriginals, str, None] = None,
+        logs: Union[Directory, str, None] = None,
+        analysis: Union[File, str, None] = None,
+        benchmarks: Union[File, str, None] = None,
+        eval_results: Union[File, str, None] = None,
+        model_card: Union[File, str, None] = None,
+        recipes: Union[List[any], str, File, None] = None,
+):
+        """
+        The function takes Files and Directories that are expected by the
+        ModelDirectory (some Files/Directories are mandatory, some are optional),
+        and then create a new Directory and copy in all those files into the correct place
+        """
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        files_dict = copy.deepcopy(locals())
+        del files_dict['output_dir']
+        for name, file in files_dict.items():
+                if file is None:
+                        logging.debug(f"File {name} not provided, skipping...")
+                else:
+                        _copy_file_contents(name, file, output_dir)
+
+def _copy_file_contents(name, file, output_dir):
+        is_dir = False
+        if isinstance(file, str):
+                path = file
+                is_dir = os.path.isdir(path)
+        elif isinstance(file, list):
+                for _file in file:
+                        if isinstance(_file, str):
+                                file = _file
+                                name = os.path.basename(_file)
+                        else:
+                                name = _file.name
+                        _copy_file_contents(name = name, file=_file, output_dir=output_dir)
+                        return
+        elif isinstance(file, Directory):
+                path = file.path
+                is_dir = True
+        else:
+                path = file.path
+
+        if name in ['training', 'deployment', 'logs']:
+                copy_path = os.path.join(output_dir, name)
+        else:
+                copy_path = os.path.join(output_dir, os.path.basename(path))
+        if is_dir:
+                shutil.copytree(path, copy_path)
+        else:
+                shutil.copyfile(path, copy_path)
+
+
+
+
+
+

--- a/src/sparsezoo/v2/helpers.py
+++ b/src/sparsezoo/v2/helpers.py
@@ -1,76 +1,120 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Helper functions pertaining to the creation of ModelDirectory
 """
 
 import copy
-from pathlib import Path
-from sparsezoo.v2 import File, Directory, NumpyDirectory, SampleOriginals
-from typing import Union, List
 import logging
 import os
 import shutil
+from pathlib import Path
+from typing import List, Optional, Union
+
+from sparsezoo.v2 import Directory, File, NumpyDirectory, SampleOriginals
+
 
 def setup_model_directory(
-        output_dir: str,
-        training: Union[str, Directory],
-        deployment: Union[str, Directory],
-        onnx_model: Union[File, str],
-        sample_inputs: Union[str, NumpyDirectory],
-        sample_outputs: Union[str, NumpyDirectory, None] = None,
-        sample_labels: Union[Directory, str, None] = None,
-        sample_originals: Union[SampleOriginals, str, None] = None,
-        logs: Union[Directory, str, None] = None,
-        analysis: Union[File, str, None] = None,
-        benchmarks: Union[File, str, None] = None,
-        eval_results: Union[File, str, None] = None,
-        model_card: Union[File, str, None] = None,
-        recipes: Union[List[any], str, File, None] = None,
-):
-        """
-        The function takes Files and Directories that are expected by the
-        ModelDirectory (some Files/Directories are mandatory, some are optional),
-        and then create a new Directory and copy in all those files into the correct place
-        """
-        Path(output_dir).mkdir(parents=True, exist_ok=True)
-        files_dict = copy.deepcopy(locals())
-        del files_dict['output_dir']
-        for name, file in files_dict.items():
-                if file is None:
-                        logging.debug(f"File {name} not provided, skipping...")
-                else:
-                        _copy_file_contents(name, file, output_dir)
+    output_dir: str,
+    training: Union[str, Directory],
+    deployment: Union[str, Directory],
+    onnx_model: Union[File, str],
+    sample_inputs: Union[str, NumpyDirectory],
+    sample_outputs: Union[
+        List[Union[str, NumpyDirectory]], str, NumpyDirectory, None
+    ] = None,
+    sample_labels: Union[Directory, str, None] = None,
+    sample_originals: Union[SampleOriginals, str, None] = None,
+    logs: Union[Directory, str, None] = None,
+    analysis: Union[File, str, None] = None,
+    benchmarks: Union[File, str, None] = None,
+    eval_results: Union[File, str, None] = None,
+    model_card: Union[File, str, None] = None,
+    recipes: Union[List[Union[str, File]], str, File, None] = None,
+) -> None:
+    """
 
-def _copy_file_contents(name, file, output_dir):
-        is_dir = False
-        if isinstance(file, str):
-                path = file
-                is_dir = os.path.isdir(path)
-        elif isinstance(file, list):
-                for _file in file:
-                        if isinstance(_file, str):
-                                file = _file
-                                name = os.path.basename(_file)
-                        else:
-                                name = _file.name
-                        _copy_file_contents(name = name, file=_file, output_dir=output_dir)
-                        return
-        elif isinstance(file, Directory):
-                path = file.path
-                is_dir = True
+    The function takes Files and Directories that are expected by the
+    ModelDirectory (some Files/Directories are mandatory, some are optional),
+    and then creates a new directory where the files are being copied to.
+    The format of the new directory adheres to the structure expected by the
+    `ModelDirectory` class factory methods.
+
+
+    :params output_dir: path to the target directory
+    :params training: pointer (path or File) to the training directory
+    :params deployment: pointer (path or File) to the deployment directory
+    :params onnx_model: pointer (path or File) to the model.onnx file
+    :params sample_inputs: pointer (path or File) to the sample_inputs directory
+    :params sample_outputs: pointer (path or File) to the sample_outputs directory
+            (also supports list of paths or Files)
+    :params sample_labels: pointer (path or File) to the sample_labels directory
+    :params sample_originals: pointer (path or File) to the sample_originals directory
+    :params logs: pointer (path or File) to the logs directory
+    :params analysis: pointer (path or File) to the analysis.yaml file
+    :params benchmarks: pointer (path or File) to the benchmarks.yaml file
+    :params eval_results: pointer (path or File) to the eval.yaml file
+    :params model_card: pointer (path or File) to the model.md file
+    :params recipes: pointer (path or File) to the recipe.yaml file
+            (also supports list of paths or Files)
+    """
+    # create new directory
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    # fetch the function arguments as a dictionary
+    files_dict = copy.deepcopy(locals())
+    del files_dict["output_dir"]
+
+    for name, file in files_dict.items():
+        if file is None:
+            logging.debug(f"File {name} not provided, skipping...")
         else:
-                path = file.path
+            if isinstance(file, str):
+                file = _create_file_from_path(file)
+            elif isinstance(file, list) and isinstance(file[0], str):
+                file = [_create_file_from_path(_file) for _file in file]
 
-        if name in ['training', 'deployment', 'logs']:
-                copy_path = os.path.join(output_dir, name)
-        else:
-                copy_path = os.path.join(output_dir, os.path.basename(path))
-        if is_dir:
-                shutil.copytree(path, copy_path)
-        else:
-                shutil.copyfile(path, copy_path)
+            _copy_file_contents(output_dir, file, name)
 
 
+def _create_file_from_path(path: str) -> Union[File, Directory]:
+    # create a File or Directory given a path
+    file = File(name=os.path.basename(path), path=path)
+    if os.path.isdir(path):
+        directory = Directory.from_file(file=file)
+        return directory
+    else:
+        return file
 
 
+def _copy_file_contents(
+    output_dir: str, file: Union[File, Directory], name: Optional[str] = None
+)-> None:
+    # optional argument `name` only used to make sure
+    # that the names of the saved folders are consistent
+    if isinstance(file, list):
+        for _file in file:
+            _copy_file_contents(output_dir, _file)
 
-
+    elif isinstance(file, Directory):
+        copy_path = (
+            os.path.join(output_dir, name)
+            if name in ["training", "deployment", "logs"]
+            else os.path.join(output_dir, os.path.basename(file.path))
+        )
+        shutil.copytree(file.path, copy_path)
+    else:
+        copy_path = os.path.join(output_dir, os.path.basename(file.path))
+        shutil.copyfile(file.path, copy_path)

--- a/tests/sparsezoo/v2/test_helpers.py
+++ b/tests/sparsezoo/v2/test_helpers.py
@@ -1,0 +1,74 @@
+import tempfile
+import pytest
+from sparsezoo.v2 import Directory, NumpyDirectory, File
+from tests.sparsezoo.v2.test_model_directory import TestModelDirectory
+from sparsezoo.v2.helpers import setup_model_directory
+from sparsezoo import Zoo
+import glob
+import os
+
+
+@pytest.mark.parametrize(
+    "stub",
+    ["zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant-aggressive_95"]
+)
+
+class TestSetupModelDirectory:
+    @pytest.fixture()
+    def setup(self, stub):
+        # setup
+        temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+        output_dir = tempfile.TemporaryDirectory(dir="/tmp")
+        model = Zoo.download_model_from_stub(stub, override_folder_name=temp_dir.name)
+
+        yield model, temp_dir, output_dir
+        temp_dir.cleanup()
+        output_dir.cleanup()
+
+    def test_setup_model_directory_from_paths(self, setup):
+        model, temp_dir, output_dir = setup
+        setup_model_directory(output_dir = output_dir.name,
+                              training = model.framework_files[0].dir_path,
+                              deployment = model.framework_files[0].dir_path,
+                              onnx_model = model.onnx_file.path,
+                              sample_inputs = model.data_inputs.path,
+                              sample_outputs = model.data_outputs.path,
+                              recipes = [model.recipes[0].path] * 2)
+
+        folders = glob.glob(os.path.join(output_dir.name, "*"))
+        assert {'training', 'deployment', 'original.md',
+                'model.onnx', 'sample-outputs.tar.gz', 'sample-inputs.tar.gz'} == set(os.path.basename(file) for file in folders)
+
+
+    def test_setup_model_directory(self, setup):
+        model, temp_dir, output_dir = setup
+        training_folder_path = model.framework_files[0].dir_path
+        training = File(name=os.path.basename(training_folder_path), path = training_folder_path)
+        training = Directory.from_file(file=training)
+
+        deployment_folder_path = model.framework_files[0].dir_path
+        deployment = File(name=os.path.basename(deployment_folder_path), path=deployment_folder_path)
+        deployment = Directory.from_file(file=deployment)
+
+        onnx_model = File(name=os.path.basename(model.onnx_file.path), path=model.onnx_file.path)
+
+        sample_inputs = File(name=os.path.basename(model.data_inputs.path), path=model.data_inputs.path)
+
+        sample_outputs = File(name=os.path.basename(model.data_outputs.path), path=model.data_outputs.path)
+
+        recipes = [File(name=os.path.basename(model.recipes[0].path), path=model.recipes[0].path)] * 2
+
+
+        setup_model_directory(output_dir=output_dir.name,
+                              training=training,
+                              deployment=deployment,
+                              onnx_model=onnx_model,
+                              sample_inputs=sample_inputs,
+                              sample_outputs=sample_outputs,
+                              recipes=recipes)
+        folders = glob.glob(os.path.join(output_dir.name, "*"))
+        assert {'training', 'deployment', 'original.md',
+                'model.onnx', 'sample-outputs.tar.gz', 'sample-inputs.tar.gz'} == set(
+            os.path.basename(file) for file in folders)
+
+

--- a/tests/sparsezoo/v2/test_helpers.py
+++ b/tests/sparsezoo/v2/test_helpers.py
@@ -1,74 +1,122 @@
-import tempfile
-import pytest
-from sparsezoo.v2 import Directory, NumpyDirectory, File
-from tests.sparsezoo.v2.test_model_directory import TestModelDirectory
-from sparsezoo.v2.helpers import setup_model_directory
-from sparsezoo import Zoo
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import glob
 import os
+import tempfile
+
+import pytest
+
+from sparsezoo import Zoo
+from sparsezoo.v2 import Directory, File
+from sparsezoo.v2.helpers import setup_model_directory
 
 
 @pytest.mark.parametrize(
     "stub",
-    ["zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant-aggressive_95"]
+    [
+        "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant-aggressive_95"  # noqa E501
+    ],
 )
-
 class TestSetupModelDirectory:
     @pytest.fixture()
     def setup(self, stub):
         # setup
         temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
-        output_dir = tempfile.TemporaryDirectory(dir="/tmp")
         model = Zoo.download_model_from_stub(stub, override_folder_name=temp_dir.name)
 
-        yield model, temp_dir, output_dir
+        yield model, temp_dir
         temp_dir.cleanup()
-        output_dir.cleanup()
 
     def test_setup_model_directory_from_paths(self, setup):
-        model, temp_dir, output_dir = setup
-        setup_model_directory(output_dir = output_dir.name,
-                              training = model.framework_files[0].dir_path,
-                              deployment = model.framework_files[0].dir_path,
-                              onnx_model = model.onnx_file.path,
-                              sample_inputs = model.data_inputs.path,
-                              sample_outputs = model.data_outputs.path,
-                              recipes = [model.recipes[0].path] * 2)
+        (
+            model,
+            temp_dir,
+        ) = setup
+        output_dir = tempfile.TemporaryDirectory(dir="/tmp")
+
+        setup_model_directory(
+            output_dir=output_dir.name,
+            training=model.framework_files[0].dir_path,
+            deployment=model.framework_files[0].dir_path,
+            onnx_model=model.onnx_file.path,
+            sample_inputs=model.data_inputs.path,
+            sample_outputs=model.data_outputs.path,
+            recipes=[model.recipes[0].path] * 2,
+        )
 
         folders = glob.glob(os.path.join(output_dir.name, "*"))
-        assert {'training', 'deployment', 'original.md',
-                'model.onnx', 'sample-outputs.tar.gz', 'sample-inputs.tar.gz'} == set(os.path.basename(file) for file in folders)
-
+        assert {
+            "training",
+            "deployment",
+            "original.md",
+            "model.onnx",
+            "sample-outputs.tar.gz",
+            "sample-inputs.tar.gz",
+        } == set(os.path.basename(file) for file in folders)
+        output_dir.cleanup()
 
     def test_setup_model_directory(self, setup):
-        model, temp_dir, output_dir = setup
+        model, temp_dir = setup
+        output_dir = tempfile.TemporaryDirectory(dir="/tmp")
+
         training_folder_path = model.framework_files[0].dir_path
-        training = File(name=os.path.basename(training_folder_path), path = training_folder_path)
+        training = File(
+            name=os.path.basename(training_folder_path), path=training_folder_path
+        )
         training = Directory.from_file(file=training)
 
         deployment_folder_path = model.framework_files[0].dir_path
-        deployment = File(name=os.path.basename(deployment_folder_path), path=deployment_folder_path)
+        deployment = File(
+            name=os.path.basename(deployment_folder_path), path=deployment_folder_path
+        )
         deployment = Directory.from_file(file=deployment)
 
-        onnx_model = File(name=os.path.basename(model.onnx_file.path), path=model.onnx_file.path)
+        onnx_model = File(
+            name=os.path.basename(model.onnx_file.path), path=model.onnx_file.path
+        )
 
-        sample_inputs = File(name=os.path.basename(model.data_inputs.path), path=model.data_inputs.path)
+        sample_inputs = File(
+            name=os.path.basename(model.data_inputs.path), path=model.data_inputs.path
+        )
 
-        sample_outputs = File(name=os.path.basename(model.data_outputs.path), path=model.data_outputs.path)
+        sample_outputs = File(
+            name=os.path.basename(model.data_outputs.path), path=model.data_outputs.path
+        )
 
-        recipes = [File(name=os.path.basename(model.recipes[0].path), path=model.recipes[0].path)] * 2
+        recipes = [
+            File(
+                name=os.path.basename(model.recipes[0].path), path=model.recipes[0].path
+            )
+        ] * 2
 
-
-        setup_model_directory(output_dir=output_dir.name,
-                              training=training,
-                              deployment=deployment,
-                              onnx_model=onnx_model,
-                              sample_inputs=sample_inputs,
-                              sample_outputs=sample_outputs,
-                              recipes=recipes)
+        setup_model_directory(
+            output_dir=output_dir.name,
+            training=training,
+            deployment=deployment,
+            onnx_model=onnx_model,
+            sample_inputs=sample_inputs,
+            sample_outputs=sample_outputs,
+            recipes=recipes,
+        )
         folders = glob.glob(os.path.join(output_dir.name, "*"))
-        assert {'training', 'deployment', 'original.md',
-                'model.onnx', 'sample-outputs.tar.gz', 'sample-inputs.tar.gz'} == set(
-            os.path.basename(file) for file in folders)
-
-
+        assert {
+            "training",
+            "deployment",
+            "original.md",
+            "model.onnx",
+            "sample-outputs.tar.gz",
+            "sample-inputs.tar.gz",
+        } == set(os.path.basename(file) for file in folders)
+        output_dir.cleanup()

--- a/tests/sparsezoo/v2/test_helpers.py
+++ b/tests/sparsezoo/v2/test_helpers.py
@@ -49,7 +49,7 @@ class TestSetupModelDirectory:
         setup_model_directory(
             output_dir=output_dir.name,
             training=model.framework_files[0].dir_path,
-            deployment=model.framework_files[0].dir_path,
+            deployment=glob.glob(os.path.join(model.framework_files[0].dir_path, "*")),
             onnx_model=model.onnx_file.path,
             sample_inputs=model.data_inputs.path,
             sample_outputs=model.data_outputs.path,
@@ -75,7 +75,7 @@ class TestSetupModelDirectory:
         training = File(
             name=os.path.basename(training_folder_path), path=training_folder_path
         )
-        training = Directory.from_file(file=training)
+        training = Directory.from_file(file=[training])
 
         deployment_folder_path = model.framework_files[0].dir_path
         deployment = File(


### PR DESCRIPTION
The goal of `setup_model_directory` is to consume the outputs from the integration pipeline and save them into one, neat directory to be further consumed to create the `ModelDirectory` class object.