### PR TITLE
More efficient ops calculation for convolutions

### DIFF
--- a/tests/sparsezoo/utils/test_onnx.py
+++ b/tests/sparsezoo/utils/test_onnx.py
@@ -74,7 +74,6 @@ def pytest_generate_tests(metafunc):
         "test_get_node_weight_name",
     ]:
         metafunc.parametrize("model_name", get_test_model_names())
-        # metafunc.parametrize("model_name", ["mobilenet_v1_pruned_moderate"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR speeds up convolution ops calculations. Rather than iterating through every spatial position in the input, we iterate through every spatial position in the kernel.

run time before
```
yolact_none: 19.475011825561523 
mobilenet_v1_pruned_moderate: 1.2140510082244873
bert_pruned_quantized: 18.289515018463135
resnet50_pruned_quantized: 2.255056142807007
```

run time after
```
yolact_none: 4.237973928451538
mobilenet_v1_pruned_moderate: 0.290449857711792
bert_pruned_quantized: 7.535924911499023
resnet50_pruned_quantized: 0.8856170177459717
```