### PR TITLE
[CI-CD Refactor] Make the Model robust to recipes that are not `.md` but `.yaml`

### DIFF
--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -122,7 +122,7 @@ def filter_files(
     for file_dict in files:
         if "recipe" in available_params and file_dict["file_type"] == "recipe":
             value = params["recipe"]
-            if file_dict["display_name"] != "recipe_" + value + ".md":
+            if file_dict["display_name"] not in "recipe_" + value:
                 continue
         if "checkpoint" in available_params and file_dict["file_type"] == "training":
             pass


### PR DESCRIPTION
I have seen that when parsing some stubs we are receiving the recipe file dictionaries from the server with the `.yaml` extension.
I am not able to reproduce that, but I can serve as an attempt to fix it.

In the future, all the recipes should be either `recipe_original.md` or `recipe_transfer_learn.md`. However, when testing sparsezoo v2 on the sparseml repo, I observed that some recipes come with a `.yaml` extension. 

This patch does account for that (basically introduces backward compatibility). But it has not been tested, so it should serve as a pointer (this is where the fix should happen) for the person who comes across this bug, rather than an ad-hoc fix.