### PR TITLE
save stub params, recipe_type backwards compat, recipe stub default logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/windows,macos,linux,python,react,pycharm,emacs,vim,visualstudio,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=windows,macos,linux,python,react,pycharm,emacs,vim,visualstudio,visualstudiocode
 
+# envs
+venv*/
+
 ### Emacs ###
 # -*- mode: gitignore; -*-
 *~


### PR DESCRIPTION
current implementation does not save zoo stub query params, does not allow for `recipe_type` (legacy) as a stub arg, and includes hard names for each possible recipe.

This will need to be further fixed to enable better defaults and more flexible file names. for now, functionality has been added to unblock recipe loading with a `recipe_type` param.

**test_plan**
verified manually against the sparseml migration
```
from sparseml.pytorch.optim import ScheduledModifierManager
m = ScheduledModifierManager.from_yaml("zoo:nlp/masked_language_modeling/bert-base/pytorch/huggingface/wikipedia_bookcorpus/12layer_pruned80_quant-none-vnni?recipe_type=transfer-text_classification")
```
(correct recipe loads)