### PR TITLE
[CI-CD Refactor] Fix silly bug in recipe filtering.

### DIFF
--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -122,7 +122,7 @@ def filter_files(
     for file_dict in files:
         if "recipe" in available_params and file_dict["file_type"] == "recipe":
             value = params["recipe"]
-            if file_dict["display_name"] not in "recipe_" + value:
+            if not file_dict["display_name"].startswith("recipe_" + value):
                 continue
         if "checkpoint" in available_params and file_dict["file_type"] == "training":
             pass


### PR DESCRIPTION
`file_dict["display_name"]` -> `"recipe_original.md"` / `"recipe_original.yaml"`
`value` -> `"original"`

## Before

```python
file_dict["display_name"] not in "recipe_" + value
```
Evaluates to `False` even though it should be `True` (`recipe_original.md`  / `recipe_original.yaml` IS NOT in `recipe_original`)

## Now 
```python
file_dict["display_name"] .startswith("recipe_" + value)
```
Evaluates to `True` (`recipe_original.md` / `recipe_original.yaml` does start with `recipe_original`)