### PR TITLE
[SparseZoo refactor] remove deepsparse from testing, update to latestt ransformers stubs, validation reqs fix

### DIFF
--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -306,6 +306,10 @@ class File:
 
     def _validate_yaml(self, strict_mode):
         try:
+            with open(self._path) as yaml_str:
+                if re.search(r"- !.+Modifier", yaml_str.read()):
+                    # YAML file contains modifier definitions, skip further validation
+                    return
             with open(self._path) as file:
                 yaml.load(file, Loader=yaml.FullLoader)
         except Exception as error:  # noqa: F841

--- a/src/sparsezoo/validation/validator.py
+++ b/src/sparsezoo/validation/validator.py
@@ -206,10 +206,12 @@ class IntegrationValidator:
         file_names = {file.name for file in loose_files}
         for optional_file in optional_validation_files:
             file_names.discard(optional_file)
-        if validation_files != file_names:
+
+        missing_validation_files = validation_files - file_names
+        if missing_validation_files:
             raise ValueError(
                 "Failed to find expected files "
-                f"{validation_files.difference(file_names)} "
+                f"{missing_validation_files} "
                 f"in the `{directory.name}` directory."
             )
 

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -115,13 +115,8 @@ class TestSetupModel:
             files_ic,
         ),
         (
-            "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant-aggressive_95",  # noqa E501
+            "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni",  # noqa E501
             False,
-            files_nlp,
-        ),
-        (
-            "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant-aggressive_95",  # noqa E501
-            True,
             files_nlp,
         ),
         (
@@ -165,8 +160,7 @@ class TestModel:
     def test_generate_outputs(self, setup):
         model, clone_sample_outputs, _, _ = setup
         if clone_sample_outputs:
-            for engine in ["onnxruntime", "deepsparse"]:
-                self._test_generate_outputs_single_engine(engine, model)
+            self._test_generate_outputs_single_engine("onnxruntime", model)
 
     @staticmethod
     def _add_mock_files(directory_path: str, clone_sample_outputs: bool):

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -69,7 +69,7 @@ EXPECTED_YOLO_FILES = {
             EXPECTED_IC_FILES,
         ),
         (
-            "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant-aggressive_95",  # noqa E501
+            "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni",  # noqa E501
             EXPECTED_NLP_FILES,
         ),
         (
@@ -96,7 +96,7 @@ def test_restructure_request_json(stub, expected_files):
 @pytest.mark.parametrize(
     "stub",
     [
-        "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant-aggressive_95"  # noqa E501
+        "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni"  # noqa E501
     ],
 )
 class TestSetupModel:


### PR DESCRIPTION
main consequence is that directory validation for integrations now checks that all required files are present - not that the entire directory matches (this allows for auxiliary files that research may want to push to be added while ensuring engineering required files are present)

**test_plan:**
after this PR sparsezoo unit tests pass locally on ubuntu 18.04