### PR TITLE
Fix handling `path` attributes for the cached files/directories

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -300,12 +300,8 @@ class Model(Directory):
                 )
                 return False
 
-        if self.model_card._path is None:
-            raise ValueError(
-                "Model card missing! Before running `validate()` "
-                "method, the respective files must be present locally. "
-                "The solution may be to call `download()` first."
-            )
+        if self.model_card is None:
+            raise ValueError("Model card missing in the model!")
 
         return self.integration_validator.validate(minimal_validation)
 

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -212,14 +212,14 @@ class File:
         return f"File(name={self.name})"
 
     def _validate_numpy(self, strict_mode):
-        if not load_numpy_list(self._path):
+        if not load_numpy_list(self.path):
             self._throw_error(
                 error_msg="Numpy file could not been loaded properly",
                 strict_mode=strict_mode,
             )
 
     def _validate_onnx(self, strict_mode):
-        if not onnx.load(self._path):
+        if not onnx.load(self.path):
             self._throw_error(
                 error_msg="Onnx file could not been loaded properly",
                 strict_mode=strict_mode,
@@ -241,7 +241,7 @@ class File:
 
     def _validate_model_card(self, strict_mode=True):
         try:
-            with open(self._path, "r") as yaml_file:
+            with open(self.path, "r") as yaml_file:
                 yaml_str = yaml_file.read()
 
             # extract YAML front matter from markdown recipe card
@@ -260,7 +260,7 @@ class File:
             return yaml_dict
 
         except Exception as error:  # noqa: F841
-            logging.error(error)
+            logging.debug(error)
 
     def _validate_markdown(self, strict_mode):
         # test if .md file is a model_card
@@ -279,7 +279,7 @@ class File:
 
     def _validate_json(self, strict_mode):
         try:
-            with open(self._path) as file:
+            with open(self.path) as file:
                 json.load(file)
         except Exception as error:  # noqa: F841
             self._throw_error(
@@ -289,7 +289,7 @@ class File:
 
     def _validate_csv(self, strict_mode):
         try:
-            with open(self._path) as file:
+            with open(self.path) as file:
                 file.readlines()
         except Exception as error:  # noqa: F841
             self._throw_error(
@@ -298,7 +298,7 @@ class File:
             )
 
     def _validate_img(self, strict_mode):
-        if not Image.open(self._path):
+        if not Image.open(self.path):
             self._throw_error(
                 error_msg="Image file could not been loaded properly",
                 strict_mode=strict_mode,
@@ -306,7 +306,7 @@ class File:
 
     def _validate_yaml(self, strict_mode):
         try:
-            with open(self._path) as yaml_str:
+            with open(self.path) as yaml_str:
                 if re.search(r"- !.+Modifier", yaml_str.read()):
                     # YAML file contains modifier definitions, skip further validation
                     return

--- a/src/sparsezoo/validation/validator.py
+++ b/src/sparsezoo/validation/validator.py
@@ -102,6 +102,8 @@ class IntegrationValidator:
             deployment_files_validation,
         ) = self.integration_to_data[integration_name]()
         for file in self.model.files:
+            if file is None:
+                continue
             # checker for dict-type file
             if isinstance(file, dict):
                 validations[file.__repr__()] = all(
@@ -148,7 +150,7 @@ class IntegrationValidator:
         """
         if self.minimal_validation:
             for file in self.model.files:
-                if isinstance(file, list) or isinstance(file, dict):
+                if isinstance(file, list) or isinstance(file, dict) or (file is None):
                     continue
                 else:
                     self.required_files.discard(file.name)


### PR DESCRIPTION
1. Using`path` for the validation instead of `_path` attribute. Rationale: it enables validating cached files (`path` should be used when we know that we have the data locally, which is the case during validation).
2. Making the `validator` more robust to absent files/directories (handling `None` files).

Test plan: 
The bug was unearthed during writing tests for QA.