### PR TITLE
Make stub string key `recipe` go with values with more versatile names

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -41,7 +41,7 @@ from sparsezoo.validation import IntegrationValidator
 __all__ = ["Model"]
 
 ALLOWED_CHECKPOINT_VALUES = {"prepruning", "postpruning", "preqat", "postqat"}
-ALLOWED_RECIPE_VALUES = {"original", "transfer_learn"}
+ALLOWED_RECIPE_VALUES = {"original", "transfer"}
 ALLOWED_DEPLOYMENT_VALUES = {"default"}
 
 PARAM_DICT = {
@@ -700,9 +700,9 @@ class Model(Directory):
                     f"String argument {key} not found in the "
                     f"expected set of string arguments {list(PARAM_DICT.keys())}!"
                 )
-            if PARAM_DICT[key] and value not in PARAM_DICT[key]:
+            if not any(expected_identifier in value for expected_identifier in PARAM_DICT[key]):
                 raise ValueError(
                     f"String argument {key} has value {value}, "
-                    "cannot be found in the "
-                    f"expected set of values {list(PARAM_DICT[key])}!"
+                    "that does not contain any of the "
+                    f"expected set of identifiers {list(PARAM_DICT[key])}!"
                 )

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -700,9 +700,17 @@ class Model(Directory):
                     f"String argument {key} not found in the "
                     f"expected set of string arguments {list(PARAM_DICT.keys())}!"
                 )
-            if not any(expected_identifier in value for expected_identifier in PARAM_DICT[key]):
-                raise ValueError(
-                    f"String argument {key} has value {value}, "
-                    "that does not contain any of the "
-                    f"expected set of identifiers {list(PARAM_DICT[key])}!"
-                )
+            if key == "recipe":
+                if not any(identifier in value for identifier in PARAM_DICT[key]):
+                    raise ValueError(
+                        f"String argument {key} has value {value}, "
+                        "that does not contain any of the "
+                        f"expected set of identifiers {list(PARAM_DICT[key])}!"
+                    )
+            else:
+                if PARAM_DICT[key] and value not in PARAM_DICT[key]:
+                    raise ValueError(
+                        f"String argument {key} has value {value}, "
+                        "cannot be found in the "
+                        f"expected set of values {list(PARAM_DICT[key])}!"
+                    )

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -41,13 +41,12 @@ from sparsezoo.validation import IntegrationValidator
 __all__ = ["Model"]
 
 ALLOWED_CHECKPOINT_VALUES = {"prepruning", "postpruning", "preqat", "postqat"}
-ALLOWED_RECIPE_VALUES = {"original", "transfer"}
 ALLOWED_DEPLOYMENT_VALUES = {"default"}
 
 PARAM_DICT = {
     "checkpoint": ALLOWED_CHECKPOINT_VALUES,
-    "recipe": ALLOWED_RECIPE_VALUES,
     "deployment": ALLOWED_DEPLOYMENT_VALUES,
+    "recipe": None,
     "recipe_type": None,  # backwards compatibility with v1 stubs
 }
 
@@ -700,17 +699,10 @@ class Model(Directory):
                     f"String argument {key} not found in the "
                     f"expected set of string arguments {list(PARAM_DICT.keys())}!"
                 )
-            if key == "recipe":
-                if not any(identifier in value for identifier in PARAM_DICT[key]):
-                    raise ValueError(
-                        f"String argument {key} has value {value}, "
-                        "that does not contain any of the "
-                        f"expected set of identifiers {list(PARAM_DICT[key])}!"
-                    )
-            else:
-                if PARAM_DICT[key] and value not in PARAM_DICT[key]:
-                    raise ValueError(
-                        f"String argument {key} has value {value}, "
-                        "cannot be found in the "
-                        f"expected set of values {list(PARAM_DICT[key])}!"
-                    )
+
+            if PARAM_DICT[key] and value not in PARAM_DICT[key]:
+                raise ValueError(
+                    f"String argument {key} has value {value}, "
+                    "cannot be found in the "
+                    f"expected set of values {list(PARAM_DICT[key])}!"
+                )

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -116,11 +116,16 @@ def filter_files(
     """
     available_params = set(params.keys())
     files_filtered = []
+    num_recipe_file_dicts = 0
     for file_dict in files:
         if "recipe" in available_params and file_dict["file_type"] == "recipe":
-            value = params["recipe"]
-            if not file_dict["display_name"].startswith("recipe_" + value):
+            expected_recipe_name = params["recipe"]
+            if not file_dict["display_name"].startswith(
+                "recipe_" + expected_recipe_name
+            ):
                 continue
+            else:
+                num_recipe_file_dicts += 1
         if "checkpoint" in available_params and file_dict["file_type"] == "training":
             pass
 
@@ -131,6 +136,17 @@ def filter_files(
 
     if not files_filtered:
         raise ValueError("No files found - the list of files is empty!")
+
+    if num_recipe_file_dicts >= 2:
+        recipe_names = [
+            file_dict["display_name"]
+            for file_dict in files_filtered
+            if file_dict["file_type"] == "recipe"
+        ]
+        raise ValueError(
+            f"Found multiple recipes: {recipe_names}, "
+            f"for the string argument {expected_recipe_name}"
+        )
     else:
         return files_filtered
 

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -59,7 +59,7 @@ files_yolo = copy.copy(files_ic)
         ),
         (
             "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
-            ("recipe", "some_dummy_name"),
+            ("checkpoint", "some_dummy_name"),
             False,
         ),
         (


### PR DESCRIPTION
Currently:
`Model._validate_params()` will throw an error if `Model` receives any other recipe string arguments other than `?recipe=original` or `?recipe=transfer_learn`.

After the patch:
We account for the fact that we may be receiving arguments with more versatile names, such as `?recipe=transfer-text_classification` or `?recipe=original_fizz_buzz`