### PR TITLE
Remove PIL from the `file.py`

### DIFF
--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import imghdr
 import json
 import logging
 import os
@@ -23,7 +24,6 @@ from typing import Any, Dict, Optional
 import onnx
 import yaml
 
-from PIL import Image
 from sparsezoo.utils import download_file, load_numpy_list
 
 
@@ -298,7 +298,8 @@ class File:
             )
 
     def _validate_img(self, strict_mode):
-        if not Image.open(self.path):
+
+        if not imghdr.what(self.path):
             self._throw_error(
                 error_msg="Image file could not been loaded properly",
                 strict_mode=strict_mode,

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -298,7 +298,6 @@ class File:
             )
 
     def _validate_img(self, strict_mode):
-
         if not imghdr.what(self.path):
             self._throw_error(
                 error_msg="Image file could not been loaded properly",


### PR DESCRIPTION
# Testing

```python
import os
from sparsezoo import File

path = "/home/damian/deepsparse_copy/src/deepsparse/yolo/sample_images/basilica.jpg"

file = File(name=os.path.basename(path), path=path)
print(file.validate()) # evaluates to True; also checked in debugger that the breakpoint follows the expected logic
```


