### PR TITLE
Add `.available_files` property to `Model

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -388,8 +388,8 @@ class Model(Directory):
     @property
     def available_files(self):
         return {
-            name: file for
-            name, file in self._files_dictionary.items()
+            name: file
+            for name, file in self._files_dictionary.items()
             if file is not None
         }
 

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -386,8 +386,12 @@ class Model(Directory):
         return loader.get_batch(bath_index=batch_index)
 
     @property
-    def available(self):
-        return {k: v for k, v in self._files_dictionary.items() if v is not None}
+    def available_files(self):
+        return {
+            name: file for
+            name, file in self._files_dictionary.items()
+            if file is not None
+        }
 
     def _get_directory(
         self,

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -385,6 +385,10 @@ class Model(Directory):
 
         return loader.get_batch(bath_index=batch_index)
 
+    @property
+    def available(self):
+        return {k: v for k, v in self._files_dictionary.items() if v is not None}
+
     def _get_directory(
         self,
         file: Dict[str, Any],


### PR DESCRIPTION
Currently, I feel like it is very difficult for the user to have a clear pathway to look up the available model files. Building on the convention established with the `SelectDirectory` class, I decided to add a property that solves that pain.

Testing:
```python
from sparsezoo import search_models

args = {
    "domain": "cv",
    "sub_domain": "segmentation",
    "architecture": "yolact",
}

models = search_models(**args)
model = models[0]
print(model.available)

>> {
>> 'training': Directory(name=training), 
>> 'deployment': Directory(name=deployment), 
>> 'sample_inputs': Directory(name=sample_inputs.tar.gz), 
>> 'sample_outputs': {'framework': Directory(name=sample_outputs.tar.gz)}, 
>> 'model_card': File(name=model.md),
>> 'recipes': Directory(name=recipe), 
>> 'onnx_model': File(name=model.onnx)
>> }
```