### PR TITLE
Add optional arg `download_path` to the Model's constructor. Disable model download overriding.

### DIFF
--- a/notebooks/model_download.ipynb
+++ b/notebooks/model_download.ipynb
@@ -88,7 +88,7 @@
     "## Selecting a model from a retrieved stub ##\n",
     "\n",
     "stub = \"zoo:cv/classification/vgg-19/pytorch/sparseml/imagenet/pruned-moderate\"\n",
-    "model = Model(stub, download_path = download_path)\n",
+    "model = Model(stub, download_path=download_path)\n",
     "print(f\"Retrieved a model\\n{str(model)}\\nfrom a stub:{stub}...\")"
    ]
   },

--- a/notebooks/model_download.ipynb
+++ b/notebooks/model_download.ipynb
@@ -88,7 +88,7 @@
     "## Selecting a model from a retrieved stub ##\n",
     "\n",
     "stub = \"zoo:cv/classification/vgg-19/pytorch/sparseml/imagenet/pruned-moderate\"\n",
-    "model = Model(stub)\n",
+    "model = Model(stub, download_path = download_path)\n",
     "print(f\"Retrieved a model\\n{str(model)}\\nfrom a stub:{stub}...\")"
    ]
   },

--- a/src/sparsezoo/download_main.py
+++ b/src/sparsezoo/download_main.py
@@ -17,7 +17,7 @@ Script to download a model from SparseZoo
 
 ##########
 Command help:
-usage: sparsezoo.download [-h] [--save-dir SAVE_DIR] [--overwrite] model_stub
+usage: sparsezoo.download [-h] [--save-dir SAVE_DIR] model_stub
 
 Download specific models from the SparseZoo repo
 
@@ -29,8 +29,6 @@ optional arguments:
   -h, --help           show this help message and exit
   --save-dir SAVE_DIR  The directory to save the model files in, defaults to
                        the cwd with the model description as a sub folder
-  --overwrite          Overwrites existing model files if previously
-                       downloaded
 
 #########
 Example download ResNet50:
@@ -74,11 +72,6 @@ def parse_args():
         help="The directory to save the model files in, "
         "defaults to the cache directory of the sparsezoo",
     )
-    parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Overwrites existing model files if previously downloaded",
-    )
 
     return parser.parse_args()
 
@@ -95,13 +88,11 @@ def main():
     if not args.model_stub.startswith("zoo:"):
         raise ValueError("Model stub must start with 'zoo:'")
 
-    model = Model(args.model_stub)
     if args.save_dir:
-        model.path = args.save_dir
-        if args.overwrite:
-            model.download(override=args.overwrite)
-        else:
-            model.download()
+        model = Model(args.model_stub, download_path=args.save_dir)
+    else:
+        model = Model(args.model_stub)
+    model.download()
 
     print("Download results")
     print("====================")

--- a/src/sparsezoo/main.py
+++ b/src/sparsezoo/main.py
@@ -290,11 +290,6 @@ def parse_args():
         help="The directory to save the model files in, "
         "defaults to the cache directory of the sparsezoo",
     )
-    download_parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Overwrites existing model files if previously downloaded",
-    )
 
     search_parser.add_argument(
         "--page", type=int, default=1, help="The page of search results to view"
@@ -391,11 +386,12 @@ def main():
             release_version=args.release_version,
         )
 
-        model = Model(stub)
         if args.save_dir:
-            model.download(directory_path=args.save_dir)
+            model = Model(stub, download_path=args.save_dir)
         else:
-            model.download()
+            model = Model(stub)
+
+        model.download()
 
         print("Download results")
         print("====================")

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -77,7 +77,7 @@ class Model(Directory):
             # initializing the files and params from the stub
             files, path, url = self.initialize_model_from_stub(self.source)
             if download_path is not None:
-                path = download_path
+                path = download_path  # overwrite cache path with user input
         else:
             # initializing the model from the path
             files, path, url = self.initialize_model_from_directory(self.source)
@@ -85,7 +85,7 @@ class Model(Directory):
                 raise ValueError(
                     "Ambiguous input to the constructor. "
                     "When attempting to create Model from a local directory path, "
-                    f"`download_path` argument should be None, not {download_path}!"
+                    f"`download_path` argument should be None, not {download_path}"
                 )
 
         self.path = path
@@ -248,7 +248,7 @@ class Model(Directory):
         # downloading is not possible
         if os.path.isdir(download_path) and os.listdir(download_path):
             raise ValueError(
-                "Attempting to download the model files to already existing directory!"
+                f"Attempting to download the model files to already existing directory {download_path}"
             )
         else:
             downloads = []

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -243,7 +243,7 @@ class Model(Directory):
         Attempt to download the files given the `url` attribute
         of the files inside the Model. To avoid the risk of corrupting
         the files while downloading, they are firstly downloaded to
-        a temporary directory, validated and finally copied over to the
+        a temporary directory, validated, and finally copied over to the
         target path of the model.
 
         :param strict_mode: if True, will throw error if any file, that is

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -68,7 +68,7 @@ class Model(Directory):
             e.g. `/home/user/model_path`
     """
 
-    def __init__(self, source: str):
+    def __init__(self, source: str, download_path: Optional[str] = None):
 
         self.source = source
         self._stub_params = {}
@@ -76,9 +76,17 @@ class Model(Directory):
         if self.source.startswith(ZOO_STUB_PREFIX):
             # initializing the files and params from the stub
             files, path, url = self.initialize_model_from_stub(self.source)
+            if download_path is not None:
+                path = download_path
         else:
             # initializing the model from the path
             files, path, url = self.initialize_model_from_directory(self.source)
+            if download_path is not None:
+                raise ValueError(
+                    "Ambiguous input to the constructor. "
+                    "When attempting to create Model from a local directory path, "
+                    f"`download_path` argument should be None, not {download_path}!"
+                )
 
         self.path = path
 
@@ -223,43 +231,30 @@ class Model(Directory):
 
     def download(
         self,
-        directory_path: Optional[str] = None,
-        override: bool = False,
         strict_mode: bool = False,
     ) -> bool:
         """
         Attempt to download the files given the `url` attribute
         of the files inside the Model.
 
-        :param directory_path: directory to download files to. If not specified,
-            will use the `self._path` attribute.
-        :param override: if True, the method can override old `directory_path`
         :param strict_mode: if True, will throw error if any file, that is
             attempted to be downloaded, turns out to be `None`.
             By default, False.
         :return: boolean flag; was download successful or not.
         """
-        if directory_path is None:
-            directory_path = self._path
+        download_path = self._path
 
         # if directory exists and is not empty, make sure that
-        # downloading is not possible unless `override` is True
-        if (
-            os.path.isdir(directory_path)
-            and os.listdir(directory_path)
-            and not override
-        ):
+        # downloading is not possible
+        if os.path.isdir(download_path) and os.listdir(download_path):
             raise ValueError(
-                "Model class object was either created "
-                "using path that points to a local directory or "
-                "`download()` method already invoked."
-                "Set `override` = True to override."
+                "Attempting to download the model files to already existing directory!"
             )
         else:
             downloads = []
             for key, file in self._files_dictionary.items():
                 if file is not None:
-                    downloads.append(self._download(file, directory_path))
+                    downloads.append(self._download(file, download_path))
                 else:
                     if strict_mode:
                         raise ValueError(
@@ -271,7 +266,6 @@ class Model(Directory):
                             f"Attempted to download file {key}, "
                             f"but it is `None`. The file is being skipped..."
                         )
-        self.path = directory_path
         return all(downloads)
 
     def validate(

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -257,7 +257,8 @@ class Model(Directory):
         # downloading is not possible
         if os.path.isdir(download_path) and os.listdir(download_path):
             raise ValueError(
-                f"Attempting to download the model files to already existing directory {download_path}"
+                "Attempting to download the model files "
+                f"to already existing directory {download_path}"
             )
         else:
             downloads = []

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -266,7 +266,7 @@ class Directory(File):
         """
         files = []
         if extract_directory is None:
-            extract_directory = os.path.dirname(self.path)
+            extract_directory = os.path.dirname(self._path)
 
         if not self.is_archive:
             raise ValueError(

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -193,9 +193,9 @@ class Directory(File):
                 file.download(
                     destination_path=os.path.join(destination_path, self.name)
                 )
-                file.path = os.path.join(destination_path, self.name, file.name)
+                file._path = os.path.join(destination_path, self.name, file.name)
 
-        self.path = os.path.join(destination_path, self.name)
+        self._path = os.path.join(destination_path, self.name)
 
     def get_file(self, file_name: str) -> Optional[File]:
         """
@@ -318,7 +318,7 @@ def is_directory(file: File) -> bool:
     if file._path is None:
         from pathlib import Path
 
-        # we are processing a downladable file
+        # we are processing a downloadable file
         file_name_without_extension = Path(file.name).stem
         return file_name_without_extension == file.name
 

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -60,7 +60,7 @@ class File:
         # has a local path attached to it. Therefore,
         # either has been downloaded or can be
         # downloaded
-        self.path = path
+        self._path = path
         self.parent_directory = parent_directory
 
         # self._path can have any extension, including no extension.
@@ -85,7 +85,7 @@ class File:
         if self._path is None:
             expected_path = os.path.join(self.parent_directory, self.name)
             if os.path.exists(expected_path):
-                self.path = expected_path
+                self._path = expected_path
                 return expected_path
             else:
                 self.download()
@@ -94,10 +94,6 @@ class File:
             self.download()
 
         return self._path
-
-    @path.setter
-    def path(self, value):
-        self._path = value
 
     @classmethod
     def from_dict(

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -88,13 +88,11 @@ class TestSetupModel:
         temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
         path = stub + "?" + args[0] + "=" + args[1]
         if should_pass:
-            model = Model(path)
-            model.download(directory_path=temp_dir.name)
+            model = Model(path, temp_dir.name)
             self._assert_correct_files_downloaded(model, args)
         else:
             with pytest.raises(ValueError):
                 model = Model(path)
-                model.download(directory_path=temp_dir.name)
 
     @staticmethod
     def _assert_correct_files_downloaded(model, args):
@@ -131,8 +129,8 @@ class TestModel:
     @pytest.fixture()
     def setup(self, stub, clone_sample_outputs, expected_files):
         temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
-        model = Model(stub)
-        model.download(directory_path=temp_dir.name)
+        model = Model(stub, temp_dir.name)
+        model.download()
         self._add_mock_files(temp_dir.name, clone_sample_outputs=clone_sample_outputs)
         model = Model(temp_dir.name)
 

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -145,6 +145,7 @@ class TestSetupModel:
     def test_setup_model_from_objects(self, setup):
         stub, temp_dir, download_dir = setup
         model = Model(stub, download_dir.name)
+        model.download()
         model.sample_inputs.unzip()
 
         training = model.training

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -146,7 +146,7 @@ class TestSetupModel:
 
     def test_setup_model_from_objects(self, setup):
         model, temp_dir, download_dir = setup
-        model.download(download_dir.name)
+        model.path = download_dir.name
         model.sample_inputs.unzip()
 
         training = model.training

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -105,20 +105,18 @@ class TestSetupModel:
         # setup
         temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
         download_dir = tempfile.TemporaryDirectory(dir="/tmp")
-        model = Model(stub)
-        model.path = download_dir.name
-
-        yield model, temp_dir, download_dir
+        yield stub, temp_dir, download_dir
         temp_dir.cleanup()
         download_dir.cleanup()
 
     def test_setup_model_from_paths(self, setup):
         (
-            model,
+            stub,
             temp_dir,
             download_dir,
         ) = setup
 
+        model = Model(stub, download_dir.name)
         training_path = model.training.path
         deployment_path = model.deployment.path
         onnx_model_path = model.onnx_model.path
@@ -145,8 +143,8 @@ class TestSetupModel:
         } == set(os.listdir(temp_dir.name))
 
     def test_setup_model_from_objects(self, setup):
-        model, temp_dir, download_dir = setup
-        model.path = download_dir.name
+        stub, temp_dir, download_dir = setup
+        model = Model(stub, download_dir.name)
         model.sample_inputs.unzip()
 
         training = model.training


### PR DESCRIPTION
## Testing:

### Making sure that the changes do not break our main repos

- [x] Testing with integrations (transformers, yolo, yolact)
- [x] Testing with SparseML
- [x] Testing with Deepsparse

### Manual testing

```python
from sparsezoo import Model

stubs_to_test = [

    "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned_quant-moderate",
    "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned95_obs_quant-none",
    "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94"
]

for stub in stubs_to_test:
    print(stub)
    model = Model(stub, download_path = '/home/damian/testing' + stub.split("/")[-1])
    print(f'Model (from stub) path: {model.path}')
    assert model.validate(validate_onnxruntime = False, minimal_validation=True)

    model_ = Model(model.path)
    print(f'Model (from dir) path: {model_.path}')
    assert model_.validate(validate_onnxruntime=False, minimal_validation=True)
 ```


<img width="696" alt="image" src="https://user-images.githubusercontent.com/97082108/182867149-3733cd4d-b7d5-49d3-ab80-0b44e8874809.png">
