### PR TITLE
More appropriate dataset naming for `sample_inputs`/`sample_outputs`

### DIFF
--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -105,7 +105,12 @@ class NumpyDirectory(Directory):
 
         :return: The created dataset from the sample data files
         """
-        return Dataset(self.name, self.path)
+
+        # sample_{...} or sample_{...}.tar.gz --> sample_{...}
+        dataset_name = self.name.split(".")[0]
+        # sample_{...} --> {...} ("inputs" or "outputs")
+        dataset_name = dataset_name.split("_")[-1]
+        return Dataset(dataset_name, self.path)
 
     def loader(
         self, batch_size: int = 1, iter_steps: int = 0, batch_as_list: bool = True


### PR DESCRIPTION
Before:

```python
inputs = model.sample_batch(batch_size=batch_size, batch_as_list=True)
>> OrderedDict([('sample_inputs.tar.gz', [array([[ 101, 2029, 5088, ...,    0,    0,    0], ...
```

Now:

```python
inputs = model.sample_batch(batch_size=batch_size, batch_as_list=True)
>> OrderedDict([('inputs', [array([[ 101, 2029, 5088, ...,    0,    0,    0], ...
```