### PR TITLE
undo stripping of `sample_` from datasets names

### DIFF
--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -108,8 +108,6 @@ class NumpyDirectory(Directory):
 
         # sample_{...} or sample_{...}.tar.gz --> sample_{...}
         dataset_name = self.name.split(".")[0]
-        # sample_{...} --> {...} ("inputs" or "outputs")
-        dataset_name = dataset_name.split("_")[-1]
         return Dataset(dataset_name, self.path)
 
     def loader(


### PR DESCRIPTION
breaking existing flows and checks. future uploads to zoo should account for new naming schema without breaking backwards compatibility by adding this strip