### PR TITLE
[cherry-pick] 1.1 tokenizer config deployment

### DIFF
--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -276,6 +276,16 @@ def restructure_request_json(
             file_dict_deployment["file_type"] = "deployment"
             request_json.append(file_dict_deployment)
 
+        # add tokenizer_config.json if available
+        tok_config_dict_training_list = fetch_from_request_json(
+            request_json, "display_name", "tokenizer_config.json"
+        )
+        if len(tok_config_dict_training_list) >= 1:
+            _, tok_config_dict_training = tok_config_dict_training_list[0]
+            tok_config_dict_deployment = copy.copy(tok_config_dict_training)
+            tok_config_dict_deployment["file_type"] = "deployment"
+            request_json.append(tok_config_dict_deployment)
+
     # create recipes
     recipe_dicts_list = fetch_from_request_json(request_json, "file_type", "recipe")
     for (idx, file_dict) in recipe_dicts_list:

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -213,7 +213,6 @@ class Directory(File):
                 file = file.get_file(file_name=file_name)
                 if file:
                     return file
-        logging.warning(f"File with name {file_name} not found")
         return None
 
     def gzip(self, archive_directory: Optional[str] = None):


### PR DESCRIPTION
This is done to address issues with tokenizer_config.json not showing up in the nlp deployment folder.

https://github.com/neuralmagic/sparsezoo/pull/215