### PR TITLE
removing Directory get_file not found warning

### DIFF
--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -213,7 +213,6 @@ class Directory(File):
                 file = file.get_file(file_name=file_name)
                 if file:
                     return file
-        logging.warning(f"File with name {file_name} not found")
         return None
 
     def gzip(self, archive_directory: Optional[str] = None):


### PR DESCRIPTION
warning not needed as function returns an optional, user should be validating the optional output