### PR TITLE
add check that recipe_type exists in recipe_type parsing

### DIFF
--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -249,7 +249,7 @@ class SelectDirectory(Directory):
                 return self["original"]
             # try to find recipe satisfying the recipe type
             for recipe_name in self.files_dict:
-                if recipe_type.lower() == recipe_name.lower():
+                if recipe_type and recipe_type.lower() == recipe_name.lower():
                     return self[recipe_name]
         if self.name == "training" and "preqat" in self.files_dict:
             return self["preqat"]


### PR DESCRIPTION
fixes issue found in QA testing
```
>>> recipe_path = zoo_model.recipes.default.path
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/release/venv/lib/python3.8/site-packages/sparsezoo/objects/directories.py", line 252, in default
    if recipe_type.lower() == recipe_name.lower():
AttributeError: 'NoneType' object has no attribute 'lower'
```