### PR TITLE
Analysis tool: Handle invalid shapes, better erroring if ort is not installed

### DIFF
--- a/src/sparsezoo/utils/node_inference.py
+++ b/src/sparsezoo/utils/node_inference.py
@@ -69,7 +69,7 @@ def extract_nodes_shapes_and_dtypes_ort(
     :param model: an ONNX model
     :return: a list of NodeArg with their shape exposed
     """
-    import onnxruntime  # import protected by @require_onnxruntime()
+    import onnxruntime
 
     model_copy = deepcopy(model)
 
@@ -178,11 +178,10 @@ def extract_nodes_shapes_and_dtypes(
     try:
         output_shapes, output_dtypes = extract_nodes_shapes_and_dtypes_ort(model)
     except Exception as err:
-        _LOGGER.warning(
-            "Extracting shapes using ONNX Runtime session failed: {}".format(err)
-        )
+        _LOGGER.warning(f"Extracting shapes using ONNX Runtime session failed: {err}")
 
     if output_shapes is None or output_dtypes is None:
+        _LOGGER.warning("Falling back to ONNX shape_inference")
         try:
             (
                 output_shapes,


### PR DESCRIPTION
Previously the tool would error out after attempting to calculate the ops for a model if onnxruntime was not installed. Now, warnings make it clear that shape inference without ort is not preferred and specifies which nodes (if any) had to be skipped because of their invalid shapes.

```
WARNING:sparsezoo.utils.node_inference:Extracting shapes using ONNX Runtime session failed: No module named 'onnxruntime'
WARNING:sparsezoo.utils.node_inference:Falling back to ONNX shape_inference
WARNING:sparsezoo.utils.calculate_ops:Invalid shape, skipping ops calculation for Conv_0
```

I've tested by running analysis with one of every kind of architecture and none of the tested models produced an error.