### PR TITLE
Make `sample_batch` method more intuitive

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -372,7 +372,7 @@ class Model(Directory):
         )
 
     def sample_batch(
-        self, batch_index: int = 0, batch_size: int = 1, batch_as_list: bool = True
+        self, batch_size: int = 1, batch_index: int = 0, batch_as_list: bool = True
     ) -> Union[List[numpy.ndarray], Dict[str, numpy.ndarray]]:
         """
         Get a sample batch of data from the data loader


### PR DESCRIPTION
From the user perspective, I felt that it is really annoying that the method:
```python
model.sample_batch(5)
```
does not do what I would suppose it naturally should do,  i.e. return a batch of data where `batch_size` is 5.

As of now, the first argument is the batch index, which I find super counterintuitive. 
To my mind, without reading the docstrings or looking at arguments' names, it feels natural that the first argument should be the batch size.