### PR TITLE
Relax click dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ _deps = [
     "requests>=2.0.0",
     "tqdm>=4.0.0",
     "pydantic>=1.8.2",
-    "click==8.0",
+    "click~=8.0.0",
     "protobuf>=3.12.2,<4",
 ]
 _notebook_deps = ["ipywidgets>=7.0.0", "jupyter>=1.0.0"]


### PR DESCRIPTION
Because click~=8.0.0 is explicitly not allowed by wandb, this PR allows minor version updates to click.

Tested by installing with dev dependencies (black). Because there are no click commands in deepsparse, there were no commands to test.