### PR TITLE
get recipes from root

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -21,6 +21,7 @@ import numpy
 
 from sparsezoo.inference import ENGINES, InferenceRunner
 from sparsezoo.model.utils import (
+    RECIPES_REGEX,
     SAVE_DIR,
     ZOO_STUB_PREFIX,
     load_files_from_directory,
@@ -142,7 +143,11 @@ class Model(Directory):
 
         self.logs: Directory = self._directory_from_files(files, display_name="logs")
 
-        self.recipes: SelectDirectory = self._directory_from_files(
+        self.recipes: Union[SelectDirectory, Directory] = self._file_from_files(
+            files,
+            display_name=RECIPES_REGEX,
+            regex=True,
+        ) or self._directory_from_files(
             files,
             directory_class=SelectDirectory,
             display_name="recipe",
@@ -168,7 +173,7 @@ class Model(Directory):
                 sample_outputs.files.sort(key=lambda x: x.name)
                 for sample_outputs in self.sample_outputs.values()
             ]
-
+        print(self.recipes)
         self._files_dictionary = {
             "training": self.training,
             "deployment": self.deployment,

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -143,7 +143,7 @@ class Model(Directory):
 
         self.logs: Directory = self._directory_from_files(files, display_name="logs")
 
-        self.recipes: Union[SelectDirectory, Directory] = self._file_from_files(
+        self.recipes: Union[SelectDirectory, List[File]] = self._file_from_files(
             files,
             display_name=RECIPES_REGEX,
             regex=True,
@@ -173,7 +173,7 @@ class Model(Directory):
                 sample_outputs.files.sort(key=lambda x: x.name)
                 for sample_outputs in self.sample_outputs.values()
             ]
-        print(self.recipes)
+
         self._files_dictionary = {
             "training": self.training,
             "deployment": self.deployment,

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -52,6 +52,7 @@ _LOGGER = logging.getLogger(__name__)
 ZOO_STUB_PREFIX = "zoo:"
 CACHE_DIR = os.path.expanduser(os.path.join("~", ".cache", "sparsezoo"))
 SAVE_DIR = os.getenv("SPARSEZOO_MODELS_PATH", CACHE_DIR)
+RECIPES_REGEX = "^recipe(.*).md$"
 
 
 def load_files_from_directory(directory_path: str) -> List[Dict[str, Any]]:


### PR DESCRIPTION
Problem:
Given a [model repo](https://git.neuralmagic.com/neuralmagic/cary), cannot get recipes*.md files from root
```python3

model = Model(model_path)
files = model.files
```

Before:
`files` does not contain recipes in root

After:
`files` contain recipes in root
