### PR TITLE
Make `Model.eval_results` more robust

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -155,7 +155,7 @@ class Model(Directory):
         self.benchmarks: File = self._file_from_files(
             files, display_name="benchmarks.yaml"
         )
-        self.eval_results: File = self._file_from_files(files, display_name="eval.yaml")
+        self.eval_results: File = self._get_eval_results(files)
 
         # sorting name of `sample_inputs` and `sample_output` files,
         # so that they have same one-to-one correspondence when we jointly
@@ -200,6 +200,13 @@ class Model(Directory):
         )
 
         self.integration_validator = IntegrationValidator(model=self)
+
+    def _get_eval_results(self, files):
+        return (
+            self._file_from_files(files, display_name="eval.yaml")
+            or self._file_from_files(files, display_name=".*eval.*", regex=True)
+            or self._file_from_files(files, display_name=".*validation.*", regex=True)
+        )
 
     @property
     def stub_params(self) -> Dict[str, str]:

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -101,7 +101,7 @@ class TestSetupModel:
         elif args[0] == "checkpoint":
             assert len(model.training.available) == 1
         elif args[0] == "deployment":
-            assert len(model.training.available) == 1
+            assert len(model.deployment.available) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -53,22 +53,30 @@ files_yolo = copy.copy(files_ic)
     "stub, args, should_pass",
     [
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
+            "-moderate",
+            # noqa E501
             ("recipe", "transfer_learn"),
             True,
         ),
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
+            "-moderate",
+            # noqa E501
             ("checkpoint", "some_dummy_name"),
             False,
         ),
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
+            "-moderate",
+            # noqa E501
             ("deployment", "default"),
             True,
         ),
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
+            "-moderate",
+            # noqa E501
             ("checkpoint", "preqat"),
             True,
         ),
@@ -108,17 +116,23 @@ class TestSetupModel:
     "stub, clone_sample_outputs, expected_files",
     [
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
+            "-moderate",
+            # noqa E501
             True,
             files_ic,
         ),
         (
-            "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni",  # noqa E501
+            "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad"
+            "/pruned80_quant-none-vnni",
+            # noqa E501
             False,
             files_nlp,
         ),
         (
-            "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94",  # noqa E501
+            "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant"
+            "-aggressive_94",
+            # noqa E501
             True,
             files_yolo,
         ),
@@ -244,3 +258,25 @@ class TestModel:
 
         if engine == "onnxruntime":
             assert os.path.isfile(tar_file_expected_path)
+
+
+@pytest.mark.parametrize(
+    "stub, has_results",
+    [
+        (
+            "zoo:nlp/text_classification/bert-base/pytorch/huggingface/mnli"
+            "/12layer_pruned90-none",
+            True,
+        ),
+        (
+            "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet"
+            "/pruned95_quant-none",
+            False,
+        ),
+    ],
+)
+def test_model_has_eval_results(stub, has_results):
+    if has_results:
+        assert Model(stub).eval_results is not None
+    else:
+        assert Model(stub).eval_results is None

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -53,30 +53,22 @@ files_yolo = copy.copy(files_ic)
     "stub, args, should_pass",
     [
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
-            "-moderate",
-            # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
             ("recipe", "transfer_learn"),
             True,
         ),
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
-            "-moderate",
-            # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
             ("checkpoint", "some_dummy_name"),
             False,
         ),
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
-            "-moderate",
-            # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
             ("deployment", "default"),
             True,
         ),
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
-            "-moderate",
-            # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
             ("checkpoint", "preqat"),
             True,
         ),
@@ -116,23 +108,17 @@ class TestSetupModel:
     "stub, clone_sample_outputs, expected_files",
     [
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned"
-            "-moderate",
-            # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
             True,
             files_ic,
         ),
         (
-            "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad"
-            "/pruned80_quant-none-vnni",
-            # noqa E501
+            "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni",  # noqa E501
             False,
             files_nlp,
         ),
         (
-            "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant"
-            "-aggressive_94",
-            # noqa E501
+            "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94",  # noqa E501
             True,
             files_yolo,
         ),


### PR DESCRIPTION
In it's current form the codebase only relies on `eval.yaml` to get eval_results; this PR adds support to rely on. regex search for filenames containing eval/validation in them in case normal pathway fails

Also fixes a small typo in tests
Adds an extra test for eval results