### PR TITLE
Refactoring & testing utils/authentication.py

### DIFF
--- a/src/sparsezoo/utils/authentication.py
+++ b/src/sparsezoo/utils/authentication.py
@@ -74,22 +74,28 @@ def get_auth_header(
 
 def _maybe_load_token(path: str):
     if not os.path.exists(path):
+        _LOGGER.debug(f"No sparse zoo credentials files found at {path}")
         return None
+
+    _LOGGER.debug(f"Loading sparse zoo credentials from {path}")
 
     with open(path) as fp:
         creds = yaml.safe_load(fp)
 
     if creds is None or CREDENTIALS_YAML_TOKEN_KEY not in creds:
+        _LOGGER.debug(f"No sparse zoo credentials found at {path}")
         return None
 
     info = creds[CREDENTIALS_YAML_TOKEN_KEY]
     if "token" not in info or "created" not in info:
+        _LOGGER.debug(f"No sparse zoo credentials found at {path}")
         return None
 
     date_created = datetime.fromtimestamp(info["created"], tz=timezone.utc)
     creation_difference = datetime.now(tz=timezone.utc) - date_created
 
     if creation_difference.days > 30:
+        _LOGGER.debug(f"Expired sparse zoo credentials at {path}")
         return None
 
     return info["token"]

--- a/src/sparsezoo/utils/authentication.py
+++ b/src/sparsezoo/utils/authentication.py
@@ -50,7 +50,7 @@ def get_auth_header(
 ) -> Dict:
     """
     Obtain an authentication header token from either credentials file or from APIs
-    if token is over 1 day old. Location of credentials file can be changed by setting
+    if token is over 30 day old. Location of credentials file can be changed by setting
     the environment variable `NM_SPARSE_ZOO_CREDENTIALS`.
 
     Currently only 'public' authentication type is supported.

--- a/tests/sparsezoo/utils/test_authentication.py
+++ b/tests/sparsezoo/utils/test_authentication.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,6 +37,9 @@ def test_load_token_yaml_fail(tmp_path):
     assert _maybe_load_token(path) is None
 
 
+_OLD_DATE = (datetime.now() - timedelta(days=40)).timestamp()
+
+
 @pytest.mark.parametrize(
     "content",
     [
@@ -44,11 +47,7 @@ def test_load_token_yaml_fail(tmp_path):
         {CREDENTIALS_YAML_TOKEN_KEY: {}},
         {CREDENTIALS_YAML_TOKEN_KEY: {"token": "asdf"}},
         {CREDENTIALS_YAML_TOKEN_KEY: {"created": "asdf"}},
-        {
-            CREDENTIALS_YAML_TOKEN_KEY: {
-                "created": (datetime.now() - timedelta(days=40)).timestamp()
-            }
-        },
+        {CREDENTIALS_YAML_TOKEN_KEY: {"created": _OLD_DATE}},
     ],
 )
 def test_load_token_failure_cases(tmp_path, content):

--- a/tests/sparsezoo/utils/test_authentication.py
+++ b/tests/sparsezoo/utils/test_authentication.py
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
 from sparsezoo.utils.authentication import (
-    get_auth_header,
-    _maybe_load_token,
-    _save_token,
     CREDENTIALS_YAML_TOKEN_KEY,
     NM_TOKEN_HEADER,
+    _maybe_load_token,
+    _save_token,
+    get_auth_header,
 )
-import pytest
-from datetime import datetime, timedelta
-import yaml
-from unittest.mock import patch, MagicMock
 
 
 def test_load_token_no_path(tmp_path):

--- a/tests/sparsezoo/utils/test_authentication.py
+++ b/tests/sparsezoo/utils/test_authentication.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sparsezoo.utils.authentication import (
+    get_auth_header,
+    _maybe_load_token,
+    _save_token,
+    CREDENTIALS_YAML_TOKEN_KEY,
+    NM_TOKEN_HEADER,
+)
+import pytest
+from datetime import datetime, timedelta
+import yaml
+from unittest.mock import patch, MagicMock
+
+
+def test_load_token_no_path(tmp_path):
+    path = str(tmp_path / "token.yaml")
+    assert _maybe_load_token(path) is None
+
+
+def test_load_token_yaml_fail(tmp_path):
+    path = str(tmp_path / "token.yaml")
+    with open(path, "w") as fp:
+        fp.write("asdf")
+    assert _maybe_load_token(path) is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        {},
+        {CREDENTIALS_YAML_TOKEN_KEY: {}},
+        {CREDENTIALS_YAML_TOKEN_KEY: {"token": "asdf"}},
+        {CREDENTIALS_YAML_TOKEN_KEY: {"created": "asdf"}},
+        {
+            CREDENTIALS_YAML_TOKEN_KEY: {
+                "created": (datetime.now() - timedelta(days=40)).timestamp()
+            }
+        },
+    ],
+)
+def test_load_token_failure_cases(tmp_path, content):
+    path = str(tmp_path / "token.yaml")
+    with open(path, "w") as fp:
+        yaml.dump(content, fp)
+    assert _maybe_load_token(path) is None
+
+
+def test_load_token_valid(tmp_path):
+    auth = {
+        CREDENTIALS_YAML_TOKEN_KEY: {
+            "created": datetime.now().timestamp(),
+            "token": "asdf",
+        }
+    }
+    path = str(tmp_path / "token.yaml")
+    with open(path, "w") as fp:
+        yaml.dump(auth, fp)
+    assert _maybe_load_token(path) == "asdf"
+
+
+def test_load_saved_token(tmp_path):
+    path = str(tmp_path / "some" / "dirs" / "token.yaml")
+    _save_token("asdf", datetime.now().timestamp(), path)
+    assert _maybe_load_token(path) == "asdf"
+
+
+@patch("requests.post", return_value=MagicMock(json=lambda: {"token": "qwer"}))
+def test_get_auth_token(post_mock, tmp_path):
+    path = tmp_path / "creds.yaml"
+    assert not path.exists()
+    assert get_auth_header(path=str(path)) == {NM_TOKEN_HEADER: "qwer"}
+    assert path.exists()
+    post_mock.assert_called()


### PR DESCRIPTION
This is PR is a refactor of the `sparsezoo/utils/authentication.py` module, as discussed in a previous PR. It also adds unit tests for all the functionality.

Summary:
- Replaced SparseZooCredentials class with two functions:
    - `_maybe_load_token` which tries to read in token from a path
    - `_save_token` which saves a token to a path
- The logic for loading a token is much more linear now, instead of spread across multiple methods