### PR TITLE
propagate validation results from sparsezoo to top level of Model

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -79,14 +79,14 @@ class Model(Directory):
 
         if self.source.startswith(ZOO_STUB_PREFIX):
             # initializing the files and params from the stub
-            _model_args = self.initialize_model_from_stub(stub=self.source)
-            files, path, url, validation_results, compressed_size = _model_args
+            _setup_args = self.initialize_model_from_stub(stub=self.source)
+            files, path, url, validation_results, compressed_size = _setup_args
             if download_path is not None:
                 path = download_path  # overwrite cache path with user input
         else:
             # initializing the model from the path
-            files, path, url = self.initialize_model_from_directory(self.source)
-            validation_results, compressed_size = None, None
+            files, path = self.initialize_model_from_directory(self.source)
+            validation_results, compressed_size, url = None, None, None
             if download_path is not None:
                 raise ValueError(
                     "Ambiguous input to the constructor. "
@@ -363,12 +363,10 @@ class Model(Directory):
         :return: A tuple of
             - list of file dictionaries
             - path to model directory
-            - `None` (representing a local model directory url)
         """
         files = load_files_from_directory(directory)
         path = directory
-        url = None
-        return files, path, url
+        return files, path
 
     def data_loader(
         self, batch_size: int = 1, iter_steps: int = 0, batch_as_list: bool = True
@@ -569,7 +567,7 @@ class Model(Directory):
         # a Directory() object, if successful,
         # otherwise None.
         if all([file_dict.get("file_type") for file_dict in files]):
-            # if file_dict is retrieved from the API as `files`
+            # if file_dict is retrieved from the API as `request_json`
             # first check if a directory can be created from the
             # "loose" files (alternative to parsing a .tar.gz file as
             # a directory)
@@ -681,7 +679,7 @@ class Model(Directory):
         files, directory_class, display_name, parent_directory, **kwargs
     ):
         # fetch all the loose files that belong to the directory (use `file_type` key
-        # from the `files` for proper mapping)
+        # from the `request_json` for proper mapping)
         files = [
             file_dict for file_dict in files if file_dict["file_type"] == display_name
         ]

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -20,10 +20,10 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 import numpy
 
 from sparsezoo.inference import ENGINES, InferenceRunner
+from sparsezoo.model.result_utils import ModelResult
 from sparsezoo.model.utils import (
     SAVE_DIR,
     ZOO_STUB_PREFIX,
-    ModelResult,
     load_files_from_directory,
     load_files_from_stub,
     save_outputs_to_tar,
@@ -57,7 +57,7 @@ class Model(Directory):
     Object to represent SparseZoo Model Directory.
 
     :param path: a string argument that can be one of two things:
-        a) a SparseZoo model stub:
+        a) A SparseZoo model stub:
             i) without additional string arguments
                 e.g. 'zoo:model/stub/path'
             ii) with additional string arguments (that will restrict
@@ -67,8 +67,8 @@ class Model(Directory):
         b) a local directory path
             e.g. `/home/user/model_path`
 
-    :param download_path: an optional argument to specify the download
-        directory of the Model. By default is None (the model is saved
+    :param download_path: an optional string argument to specify the download
+        directory of the Model. Defaults to `None` (the model is saved
         to sparsezoo cache directory)
     """
 
@@ -79,14 +79,14 @@ class Model(Directory):
 
         if self.source.startswith(ZOO_STUB_PREFIX):
             # initializing the files and params from the stub
-            _model_args = self.initialize_model_from_stub(self.source)
+            _model_args = self.initialize_model_from_stub(stub=self.source)
             files, path, url, validation_results, compressed_size = _model_args
             if download_path is not None:
                 path = download_path  # overwrite cache path with user input
         else:
             # initializing the model from the path
             files, path, url = self.initialize_model_from_directory(self.source)
-            validation_results = compressed_size = None
+            validation_results, compressed_size = None, None
             if download_path is not None:
                 raise ValueError(
                     "Ambiguous input to the constructor. "
@@ -159,8 +159,11 @@ class Model(Directory):
             files, display_name="benchmarks.yaml"
         )
         self.eval_results: File = self._file_from_files(files, display_name="eval.yaml")
+
         # plaintext validation metrics optionally parsed from a zoo stub
-        self.validation_results: Optional[List[ModelResult]] = validation_results
+        self.validation_results: Optional[
+            Dict[str, List[ModelResult]]
+        ] = validation_results
 
         # compressed file size on disk in bytes
         self.compressed_size: Optional[int] = compressed_size
@@ -327,21 +330,41 @@ class Model(Directory):
 
     def initialize_model_from_stub(
         self, stub: str
-    ) -> Tuple[List[Dict[str, str]], str, str, List[ModelResult], int]:
+    ) -> Tuple[List[Dict[str, str]], str, str, Dict[str, List[ModelResult]], int]:
+        """
+        :param stub: A string SparseZoo stub to initialize model from
+        :return: A tuple of
+            - list of file dictionaries
+            - local path of the model
+            - str url to the model directory on SparseZoo
+            - validation results dict
+            - compressed model size in bytes
+        """
         files, model_id, params, validation_results, size = load_files_from_stub(
-            stub, valid_params=list(PARAM_DICT.keys())
+            stub=stub,
+            valid_params=list(PARAM_DICT.keys()),
         )
         if params:
-            self._validate_params(params)
+            self._validate_params(params=params)
             self._stub_params.update(params)
 
         path = os.path.join(SAVE_DIR, model_id)
-        url = os.path.dirname(files[0]["url"])
+        if not files:
+            raise ValueError(f"No files found for given stub {stub}")
+        url = os.path.dirname(files[0].get("url"))
         return files, path, url, validation_results, size
 
+    @staticmethod
     def initialize_model_from_directory(
-        self, directory: str
+        directory: str,
     ) -> Tuple[List[Dict[str, str]], str, None]:
+        """
+        :param: The path to a local model directory
+        :return: A tuple of
+            - list of file dictionaries
+            - path to model directory
+            - `None` (representing a local model directory url)
+        """
         files = load_files_from_directory(directory)
         path = directory
         url = None
@@ -539,14 +562,14 @@ class Model(Directory):
         display_name: Optional[str] = None,
         regex: Optional[bool] = False,
         allow_multiple_outputs: Optional[bool] = False,
-        **kwargs,
+        **kwargs: object,
     ) -> Union[Directory, None]:
 
         # Takes a list of file dictionaries and returns
         # a Directory() object, if successful,
         # otherwise None.
         if all([file_dict.get("file_type") for file_dict in files]):
-            # if file_dict is retrieved from the API as `request_json`
+            # if file_dict is retrieved from the API as `files`
             # first check if a directory can be created from the
             # "loose" files (alternative to parsing a .tar.gz file as
             # a directory)
@@ -598,7 +621,7 @@ class Model(Directory):
             if file.url or (
                 file.url is None
                 and any(
-                    [isinstance(file, _class) for _class in [Directory, NumpyDirectory]]
+                    isinstance(file, _class) for _class in (Directory, NumpyDirectory)
                 )
             ):
                 file.download(destination_path=directory_path)
@@ -658,7 +681,7 @@ class Model(Directory):
         files, directory_class, display_name, parent_directory, **kwargs
     ):
         # fetch all the loose files that belong to the directory (use `file_type` key
-        # from the `request_json` for proper mapping)
+        # from the `files` for proper mapping)
         files = [
             file_dict for file_dict in files if file_dict["file_type"] == display_name
         ]

--- a/src/sparsezoo/model/result_utils.py
+++ b/src/sparsezoo/model/result_utils.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pydantic import BaseModel, Field
+
+
+class ModelResult(BaseModel):
+    """
+    Base class to store common result information
+    """
+
+    result_type: str = Field(
+        description="A string representing the type of "
+        "result ex `training`, `inference`, etc"
+    )
+    recorded_value: float = Field(description="The float value of the result")
+    recorded_units: str = Field(description="The unit in which result is specified")
+
+
+class ValidationResult(ModelResult):
+    """
+    A class holding information for validation results
+    """
+
+    dataset_type: str = Field(
+        description="A string representing the type of "
+        "dataset used ex. `upstream`, `downstream`"
+    )
+    dataset_name: str = Field(
+        description="The name of the dataset current " "result was measured on"
+    )
+
+
+class ThroughputResults(ModelResult):
+    """
+    A class holding information for throughput based results
+    """
+
+    device_info: str = Field(description="The device current result was measured on")
+    num_cores: int = Field(
+        description="Number of cores used while measuring " "this result"
+    )
+    batch_size: int = Field(
+        description="The batch size used while measuring " "this result"
+    )

--- a/src/sparsezoo/model/result_utils.py
+++ b/src/sparsezoo/model/result_utils.py
@@ -15,6 +15,9 @@
 from pydantic import BaseModel, Field
 
 
+__all__ = ["ModelResult", "ValidationResult", "ThroughputResults"]
+
+
 class ModelResult(BaseModel):
     """
     Base class to store common result information

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -115,7 +115,7 @@ def load_files_from_stub(
         - list of file dictionaries
         - model_id (from the server)
         - parsed param dictionary
-        - validation results
+        - validation results dictionary
         - compressed model size in bytes
     """
     params = None
@@ -362,14 +362,14 @@ def fetch_from_request_json(
     request_json: List[Dict[str, Any]], key: str, value: str
 ) -> List[Tuple[int, Dict[str, Any]]]:
     """
-    Searches through the `files` list to find a
-    dictionary, that contains the requested
-    key-value pair.
+    Searches through the `request_json` list to find a
+    dictionary, that contains the requested key-value pair.
+
     :param request_json: A list of file dictionaries
     :param key: lookup key for the file dictionary
     :param value: lookup value for the file dictionary
     :return a list of tuples
-        (index - the found file dictionary's position in the `files`,
+        (index - the found file dictionary's position in the `request_json`,
         the found file dictionary)
     """
     return [

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -38,6 +38,7 @@ __all__ = [
     "load_files_from_directory",
     "ZOO_STUB_PREFIX",
     "SAVE_DIR",
+    "COMPRESSED_FILE_NAME",
 ]
 
 ALLOWED_FILE_TYPES = {
@@ -59,6 +60,7 @@ _LOGGER = logging.getLogger(__name__)
 ZOO_STUB_PREFIX = "zoo:"
 CACHE_DIR = os.path.expanduser(os.path.join("~", ".cache", "sparsezoo"))
 SAVE_DIR = os.getenv("SPARSEZOO_MODELS_PATH", CACHE_DIR)
+COMPRESSED_FILE_NAME = "model.onnx.tar.gz"
 
 
 def load_files_from_directory(directory_path: str) -> List[Dict[str, Any]]:
@@ -89,9 +91,8 @@ def _get_compressed_size(files: List[Dict[str, Any]]) -> Optional[int]:
     :return: `None` if file size cannot be determined, else an int representing
         compressed size of the model in bytes
     """
-    compressed_file_name = "model.onnx.tar.gz"
     for file in files:
-        if file.get("display_name") == compressed_file_name:
+        if file.get("display_name") == COMPRESSED_FILE_NAME:
             return file.get("file_size")
 
     _LOGGER.info("Compressed file-size not found!")

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -72,6 +72,11 @@ files_yolo = copy.copy(files_ic)
             ("checkpoint", "preqat"),
             True,
         ),
+        (
+            "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant-moderate",  # noqa E501
+            ("checkpoint", "postqat"),
+            True,
+        ),
     ],
     scope="function",
 )
@@ -90,9 +95,11 @@ class TestSetupModel:
         if should_pass:
             model = Model(path, temp_dir.name)
             self._assert_correct_files_downloaded(model, args)
+            self._assert_validation_results_exist(model)
+            assert model.compressed_size
         else:
             with pytest.raises(ValueError):
-                model = Model(path)
+                Model(path)
 
     @staticmethod
     def _assert_correct_files_downloaded(model, args):
@@ -102,6 +109,11 @@ class TestSetupModel:
             assert len(model.training.available) == 1
         elif args[0] == "deployment":
             assert len(model.training.available) == 1
+
+    @staticmethod
+    def _assert_validation_results_exist(model):
+        assert model.validation_results is not None
+        assert len(model.validation_results) >= 1
 
 
 @pytest.mark.parametrize(

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -60,25 +60,25 @@ files_yolo = copy.copy(files_ic)
         ),
         (
             "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
-            "pruned-moderate",  # noqa E501
+            "pruned-moderate",
             ("checkpoint", "some_dummy_name"),
             False,
         ),
         (
             "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
-            "pruned-moderate",  # noqa E501
+            "pruned-moderate",
             ("deployment", "default"),
             True,
         ),
         (
             "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
-            "pruned-moderate",  # noqa E501
+            "pruned-moderate",
             ("checkpoint", "preqat"),
             True,
         ),
         (
             "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/"
-            "pruned_quant-moderate",  # noqa E501
+            "12layer_pruned80_quant-none-vnni",
             ("checkpoint", "postqat"),
             True,
         ),

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -53,27 +53,32 @@ files_yolo = copy.copy(files_ic)
     "stub, args, should_pass",
     [
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+            "pruned-moderate",
             ("recipe", "transfer_learn"),
             True,
         ),
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+            "pruned-moderate",  # noqa E501
             ("checkpoint", "some_dummy_name"),
             False,
         ),
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+            "pruned-moderate",  # noqa E501
             ("deployment", "default"),
             True,
         ),
         (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+            "pruned-moderate",  # noqa E501
             ("checkpoint", "preqat"),
             True,
         ),
         (
-            "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant-moderate",  # noqa E501
+            "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/"
+            "pruned_quant-moderate",  # noqa E501
             ("checkpoint", "postqat"),
             True,
         ),
@@ -113,7 +118,9 @@ class TestSetupModel:
     @staticmethod
     def _assert_validation_results_exist(model):
         assert model.validation_results is not None
-        assert len(model.validation_results) >= 1
+        assert isinstance(model.validation_results, dict)
+        assert len(model.validation_results.keys()) >= 1
+        assert any(value for value in model.validation_results.values())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Diff created by @bfineran and taken over by @rahul-tuli

adds `validation_results`, `compressed_size` fields to `Model` class to surface validation results, and deployment size displayed in the `sparsezoo` api for models loaded from a stub

example usage:
```python
>>> from sparsezoo import Model
>>> m = Model("zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/12layer_pruned80_quant-none-vnni")
>>> m.validation_results
defaultdict(list,
            {'validation': [ValidationResult(result_type='training', recorded_value=87.85, recorded_units='f1', dataset_type='downstream', dataset_name='squad')],
             'throughput': [ThroughputResults(result_type='inference', recorded_value=8.2172, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=1, batch_size=6),
              ThroughputResults(result_type='inference', recorded_value=28.8294, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=4, batch_size=1),
              ThroughputResults(result_type='inference', recorded_value=32.0241, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=4, batch_size=6),
              ThroughputResults(result_type='inference', recorded_value=7.85475, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=1, batch_size=1),
              ThroughputResults(result_type='inference', recorded_value=173.804, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=24, batch_size=1),
              ThroughputResults(result_type='inference', recorded_value=8.06775, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=1, batch_size=6),
              ThroughputResults(result_type='inference', recorded_value=182.43, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=24, batch_size=6),
              ThroughputResults(result_type='inference', recorded_value=101.71, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=24, batch_size=1),
              ThroughputResults(result_type='inference', recorded_value=32.387, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=4, batch_size=6),
              ThroughputResults(result_type='inference', recorded_value=163.771, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=24, batch_size=6),
              ThroughputResults(result_type='inference', recorded_value=8.04804, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=1, batch_size=1),
              ThroughputResults(result_type='inference', recorded_value=29.3466, recorded_units='items/seconds', device_info='c6i.12xlarge', num_cores=4, batch_size=1)]})
...
>>> m.compressed_size
37984882
```

**test_plan:**
unit tests updated