### PR TITLE
Update: `ModelAnalysis.from_onnx(...)` to work with `ModelProto` 

### DIFF
--- a/src/sparsezoo/analysis/analysis.py
+++ b/src/sparsezoo/analysis/analysis.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Optional, Union
 import numpy
 import onnx
 import yaml
-from onnx import NodeProto
+from onnx import ModelProto, NodeProto
 from pydantic import BaseModel, Field
 
 from sparsezoo.analysis.utils.models import (
@@ -424,15 +424,20 @@ class ModelAnalysis(BaseModel):
     )
 
     @classmethod
-    def from_onnx(cls, onnx_file_path: str):
+    def from_onnx(cls, onnx_file_path: Union[str, ModelProto]):
         """
         Model Analysis
 
         :param cls: class being constructed
-        :param onnx_file_path: path to onnx file being analyzed
+        :param onnx_file_path: path to onnx file, or a loaded onnx ModelProto to
+            analyze
         :return: instance of cls
         """
-        model_onnx = onnx.load(onnx_file_path)
+        model_onnx = (
+            onnx_file_path
+            if isinstance(onnx_file_path, ModelProto)
+            else onnx.load(onnx_file_path)
+        )
         model_graph = ONNXGraph(model_onnx)
 
         node_analyses = cls.analyze_nodes(model_graph)


### PR DESCRIPTION
Before this PR, `sparezoo.analysis.ModelAnalysis.from_onnx(...)` method 
worked only with filepaths to onnx files, this can be inconvenient especially
if we need to analyze an already loaded onnx model.

```python
import onnx
from sparsezoo.analysis import ModelAnalysis
onnx_model = onnx.load("./model.onnx")
ModelAnalysis.from_onnx(onnx_model)
```

Results in the following Error:
```bash
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/rahul/projects/sparsezoo/src/sparsezoo/analysis/analysis.py", line 435, in from_onnx
    model_onnx = onnx.load(onnx_file_path)
  File "/home/rahul/virtual_environments/sparsezoo3.9/lib/python3.9/site-packages/onnx/__init__.py", line 120, in load_model
    s = _load_bytes(f)
  File "/home/rahul/virtual_environments/sparsezoo3.9/lib/python3.9/site-packages/onnx/__init__.py", line 34, in _load_bytes
    with open(cast(Text, f), 'rb') as readable:
TypeError: expected str, bytes or os.PathLike object, not ModelProto
```


After this PR `ModelAnalysis` will work with both loaded onnx `ModelProto` and 
local filepaths

The same test code(after this PR) now returns a `ModelAnalysis` object
```python
ModelAnalysis(node_counts={'Conv': 53, 'Gemm': 1, 'BatchNormalization': ...
```

This will allow easier testing where we will not have to reload onnx files,
and, will be useful for upcoming `PerformanceAnalysis` api

Note: The changes added should not affect existing flows.