### PR TITLE
relax click dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ _deps = [
     "requests>=2.0.0",
     "tqdm>=4.0.0",
     "pydantic>=1.8.2",
-    "click~=8.0.0",
+    "click>=7.1.2,!=8.0.0",  # latest version < 8.0 + blocked version with reported bug
     "protobuf>=3.12.2,<4",
 ]
 _notebook_deps = ["ipywidgets>=7.0.0", "jupyter>=1.0.0"]


### PR DESCRIPTION
strict click dependency has caused issues with users who's environments pin click to less than version 8. this PR allows for enablement of click<8.0 by allowing the latest non 8.0 version only. The maximum version was also lifted as the previous restriction was to avoid installing 8.0.0, a version that had reported issues working with wandb.

*test_plan:**
Click is used only by our main entrypoint CLIs which will be in scope for manual/automated QA testing in the 1.5 release as well as any integration tests