### PR TITLE
[standardization-utils] base schemas + markdown generation impl

### DIFF
--- a/src/sparsezoo/utils/standardization/__init__.py
+++ b/src/sparsezoo/utils/standardization/__init__.py
@@ -21,3 +21,6 @@ neuralmagic integrations
 # isort: skip_file
 
 from .markdown_utils import *
+from .feature_status import *
+from .feature_status_table import *
+from .feature_status_page import *

--- a/src/sparsezoo/utils/standardization/feature_status.py
+++ b/src/sparsezoo/utils/standardization/feature_status.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utilities for representing feature status
+"""
+
+
+__all__ = [
+    "FeatureStatus",
+]
+
+
+_STATUS_TO_GITHUB_EMOJI = {
+    "y": ":white_check_mark:",  # (yes) - implemented by NM
+    "e": ":heavy_check_mark:",  # (external) - implemented by external integration
+    "n": ":x:",  # (no) - not implemented yet
+    "?": ":question:",  # (question) - not sure, not tested, or to be investigated
+}
+
+_STATUS_HELP_TEXT = """
+### Key
+ * :white_check_mark: - implemented by neuralmagic integration
+ * :heavy_check_mark: - implemented by underlying integration
+ * :x: - not implemented yet
+ * :question: - not sure, not tested, or to be investigated
+""".strip()
+
+
+class FeatureStatus(str):
+    """
+    Valid feature status codes mapped to emojis to render in github
+
+    Valid values:
+    'y' - (yes) - implemented by NM
+    'e' - (external) - implemented by external integration
+    'n' - (no) - not implemented yet
+    '?' - (question) - not sure, not tested, or to be investigated
+    """
+
+    MARKDOWN_HELP = _STATUS_HELP_TEXT
+    VALID_VALUES = list(_STATUS_TO_GITHUB_EMOJI.values())
+
+    def github_emoji(self) -> str:
+        """
+        :return: github emoji to represent this status code
+        """
+        self.validate(str(self))
+        return _STATUS_TO_GITHUB_EMOJI[self]
+
+    @classmethod
+    def __get_validators__(cls):
+        # pydantic validation
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value):
+        """
+        :param value: string value to validate
+        :raises ValueError: if the value of this status is not in the
+            approved set of status values
+        """
+        if value not in _STATUS_TO_GITHUB_EMOJI:
+            raise ValueError(
+                f"Invalid feature status code: {value}. "
+                f"Valid codes: {cls.VALID_VALUES}"
+            )
+        return cls(value)

--- a/src/sparsezoo/utils/standardization/feature_status_page.py
+++ b/src/sparsezoo/utils/standardization/feature_status_page.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Page containing a collection of feature status tables. Useful for reporting
+project(s) feature status with groups and descriptions
+"""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from sparsezoo.utils.standardization.feature_status import FeatureStatus
+from sparsezoo.utils.standardization.feature_status_table import FeatureStatusTable
+
+
+__all__ = [
+    "FeatureStatusPage",
+]
+
+
+_FEATURE_STATUS_PAGE_MARKDOWN_TEMPLATE = """
+# {project_name} {name} Status Page
+{project_description}
+
+{tables}
+
+{status_key}
+""".strip()
+
+
+class FeatureStatusPage(ABC, BaseModel):
+    """
+    Base Pydantic model that represents a project status page as a series of feature
+    status tables
+
+    Subclasses must define the name project type
+    """
+
+    project_name: str = Field(description="name of this project")
+    project_description: str = Field(
+        description="Description of this project",
+        default="",
+    )
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """
+        :return: name of project type this feature status page represents
+        """
+        raise NotImplementedError
+
+    @property
+    def description(self) -> str:
+        """
+        :return: description of this feature status page
+        """
+        return ""
+
+    @property
+    def feature_status_table_fields(self) -> List[Field]:
+        """
+        :return: Field definitions of fields in this model whose target type is
+            FeatureStatusTable. These fields will become tables on this page
+        """
+        return [
+            field
+            for field in self.__fields__.values()
+            if issubclass(field.type_, FeatureStatusTable)
+        ]
+
+    def markdown(self) -> str:
+        feature_status_table_fields = self.feature_status_table_fields
+        feature_status_table_markdowns = [
+            getattr(self, field.name).markdown()
+            for field in feature_status_table_fields
+        ]
+
+        return _FEATURE_STATUS_PAGE_MARKDOWN_TEMPLATE.format(
+            project_name=self.project_name,
+            name=self.name,
+            project_description=self.project_description,
+            tables="\n\n".join(feature_status_table_markdowns),
+            status_key=FeatureStatus.MARKDOWN_HELP,
+        )

--- a/src/sparsezoo/utils/standardization/feature_status_table.py
+++ b/src/sparsezoo/utils/standardization/feature_status_table.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Representation of feature status for a logical grouping of features
+"""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from sparsezoo.utils.standardization.feature_status import FeatureStatus
+from sparsezoo.utils.standardization.markdown_utils import create_markdown_table
+
+
+__all__ = [
+    "FeatureStatusTable",
+]
+
+
+_FEATURE_STATUS_TABLE_MARKDOWN_TEMPLATE = """
+## {name}
+{description}
+
+{table}
+""".strip()
+
+
+class FeatureStatusTable(ABC, BaseModel):
+    """
+    Base Pydantic model that includes utilities for building status tables from its
+    fields with type FeatureStatus
+
+    Subclasses must define the name property
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """
+        :return: name of feature group this status table represents
+        """
+        raise NotImplementedError
+
+    @property
+    def description(self) -> str:
+        """
+        :return: description of this feature status group
+        """
+        return ""
+
+    @property
+    def feature_status_fields(self) -> List[Field]:
+        """
+        :return: Field definitions of fields in this model whose target type is
+            FeatureStatus. These fields will be used to build tables
+        """
+        return [
+            field for field in self.__fields__.values() if field.type_ is FeatureStatus
+        ]
+
+    def markdown(self) -> str:
+        feature_status_fields = self.feature_status_fields
+        table_headers = [field.name for field in feature_status_fields]
+        table_emoji_rows = [
+            [
+                getattr(self, field.name).github_emoji()
+                for field in feature_status_fields
+            ]
+        ]
+        table = create_markdown_table(table_headers, table_emoji_rows)
+
+        return _FEATURE_STATUS_TABLE_MARKDOWN_TEMPLATE.format(
+            name=self.name,
+            description=self.description,
+            table=table,
+        )

--- a/tests/sparsezoo/utils/standardization/test_feature_status_page.py
+++ b/tests/sparsezoo/utils/standardization/test_feature_status_page.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pydantic import Field
+
+from sparsezoo.utils.standardization import (
+    FeatureStatus,
+    FeatureStatusPage,
+    FeatureStatusTable,
+)
+
+
+class FakeStatusTable1(FeatureStatusTable):
+
+    feature_1: FeatureStatus = Field()
+    feature_2: FeatureStatus = Field()
+
+    @property
+    def name(self) -> str:
+        return "fake table 1"
+
+    @property
+    def description(self) -> str:
+        return "fake description"
+
+
+class FakeStatusTable2(FeatureStatusTable):
+    @property
+    def name(self) -> str:
+        return "fake table 2"
+
+    feature_3: FeatureStatus = Field()
+    feature_4: FeatureStatus = Field()
+
+
+class FakeStatusPage(FeatureStatusPage):
+    table_1: FakeStatusTable1 = Field()
+    table_2: FakeStatusTable2 = Field()
+
+    @property
+    def name(self) -> str:
+        return "Fake Project"
+
+    @property
+    def description(self) -> str:
+        return "fake page description"
+
+
+_EXPECTED_TEST_FEATURE_STATUS_TABLE_MARKDOWN_OUTPUT = """
+# Fake Project Fake Project Status Page
+Fake project status for testing
+
+## fake table 1
+fake description
+
+| feature_1          | feature_2  |
+| ------------------ | ---------- |
+| :white_check_mark: | :question: |
+
+## fake table 2
+
+
+| feature_3 | feature_4          |
+| --------- | ------------------ |
+| :x:       | :heavy_check_mark: |
+
+### Key
+ * :white_check_mark: - implemented by neuralmagic integration
+ * :heavy_check_mark: - implemented by underlying integration
+ * :x: - not implemented yet
+ * :question: - not sure, not tested, or to be investigated
+"""
+
+
+def test_feature_status_table_markdown():
+    page = FakeStatusPage(
+        project_name="Fake Project",
+        project_description="Fake project status for testing",
+        table_1=FakeStatusTable1(
+            feature_1="y",
+            feature_2="?",
+        ),
+        table_2=FakeStatusTable2(
+            feature_3="n",
+            feature_4="e",
+        ),
+    )
+
+    assert page.markdown().strip() == (
+        _EXPECTED_TEST_FEATURE_STATUS_TABLE_MARKDOWN_OUTPUT.strip()
+    )


### PR DESCRIPTION
Implementations of three base classes that build on each other to create standardization pages
* `FeatureStatus` - character that represents status. can be one of 4 values that will be mapped to a GH emoji when rendered
* `FeatureStatusTable` - Pydantic model that is a collection of `FeatureStatus` fields. Rendered to markdown as a table with heading as name and description
* `FeatureStatusPage` - Pydantic model that is a collection of `FeatureStatusTable` fields. Rendered as a collection of feature status tables

Downstream repos will create their own subclasses of the tables and pages to create a template for status tracking. Each integration project will then be able to create their table by maintaining a YAML config for the status schema

**test_plan:**
pytest testing includes a simple expected output check on an example page

GH rendering of the test generated markdown:
# Fake Project Fake Project Status Page
Fake project status for testing

## fake table 1
fake description

| feature_1          | feature_2  |
| ------------------ | ---------- |
| :white_check_mark: | :question: |

## fake table 2


| feature_3 | feature_4          |
| --------- | ------------------ |
| :x:       | :heavy_check_mark: |

### Key
 * :white_check_mark: - implemented by neuralmagic integration
 * :heavy_check_mark: - implemented by underlying integration
 * :x: - not implemented yet
 * :question: - not sure, not tested, or to be investigated