### PR TITLE
[standardization-utils] helper fucntion for generating yaml template

### DIFF
--- a/src/sparsezoo/utils/standardization/feature_status_page.py
+++ b/src/sparsezoo/utils/standardization/feature_status_page.py
@@ -118,7 +118,7 @@ class FeatureStatusPage(ABC, BaseModel):
             status_table = getattr(self, field.name)
             yaml_str_lines.extend(status_table.yaml_str_lines(indentation="  "))
 
-        return "\n".join(yaml_str_lines)
+        return "\n".join(yaml_str_lines).replace("\n\n\n", "\n\n")
 
     def markdown(self) -> str:
         """
@@ -180,3 +180,24 @@ class FeatureStatusPage(ABC, BaseModel):
             tables="\n\n".join(table_markdowns),
             status_key=FeatureStatus.MARKDOWN_HELP,
         )
+
+    @classmethod
+    def default(cls) -> "FeatureStatusPage":
+        """
+        :return: default sattus page with all status values set to 'n'
+        """
+        default_constructor_args = {
+            field_name: field.type_.default()
+            for field_name, field in cls.__fields__.items()
+            if issubclass(field.type_, FeatureStatusTable)
+        }
+        default_constructor_args["project_name"] = "project name"
+        default_constructor_args["project_description"] = "description"
+        return cls(**default_constructor_args)
+
+    @classmethod
+    def template_yaml_str(cls) -> str:
+        """
+        :return: sample yaml string for this class with all status values set to 'n'
+        """
+        return cls.default().yaml_str()

--- a/src/sparsezoo/utils/standardization/feature_status_table.py
+++ b/src/sparsezoo/utils/standardization/feature_status_table.py
@@ -163,3 +163,16 @@ class FeatureStatusTable(ABC, BaseModel):
             description=status_tables[0].description,
             table=table,
         )
+
+    @classmethod
+    def default(cls) -> "FeatureStatusTable":
+        """
+        :return: instance of this class with "n" for every field. for template
+            generation only
+        """
+        default_statuses = {
+            field_name: "n"  # default to 'n'
+            for field_name, field in cls.__fields__.items()
+            if field.type_ is FeatureStatus
+        }
+        return cls(**default_statuses)

--- a/tests/sparsezoo/utils/standardization/test_feature_status_page.py
+++ b/tests/sparsezoo/utils/standardization/test_feature_status_page.py
@@ -195,3 +195,30 @@ def test_feature_status_table_yaml_serialization():
     page_reloaded = FakeStatusPage.from_yaml(page_yaml_str)
 
     assert page_obj == page_reloaded
+
+
+_EXPECTED_TEMPLATE_YAML_STR = """
+###########################################################
+# Status Keys:
+# y: yes - implemented by NM
+# e: external - implemented by external integration
+# n: no - not implemented yet
+# q: question - not sure, not tested, or to be investigated
+###########################################################
+
+project_name: project name
+project_description: description
+
+table_1:
+  feature_1: n
+  feature_2: n
+
+table_2:
+  feature_3: n
+  feature_4: n
+"""
+
+
+def test_feature_status_table_template_yaml_str():
+    generated_template_yaml_str = FakeStatusPage.template_yaml_str()
+    assert generated_template_yaml_str.strip() == (_EXPECTED_TEMPLATE_YAML_STR.strip())


### PR DESCRIPTION
generates a yaml template with all status values set to `n`

**test_plan:**
comparison test added

yaml template generated in test:
```yaml
###########################################################
# Status Keys:
# y: yes - implemented by NM
# e: external - implemented by external integration
# n: no - not implemented yet
# q: question - not sure, not tested, or to be investigated
###########################################################

project_name: project name
project_description: description

table_1:
  feature_1: n
  feature_2: n

table_2:
  feature_3: n
  feature_4: n
```