### PR TITLE
[Update] Workflow to point to `sparsezoo prod`

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -42,8 +42,6 @@ jobs:
         run: pip3 install .[dev]
       - name: "🔬 Running tests"
         run: make test
-        env:
-          SPARSEZOO_API_URL: https://staging-api.neuralmagic.com
   extensive-python-tests:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
GHA right now points to `sparsezoo-staging` for fetching models; this is not ideal as staging is more actively under development and might break models. Current PR updates GHA workflow to point to `sparsezoo-prod`