### PR TITLE
sparsezoo.analyze update summary printed to console

### DIFF
--- a/src/sparsezoo/analysis_cli.py
+++ b/src/sparsezoo/analysis_cli.py
@@ -50,7 +50,6 @@ import click
 from sparsezoo import Model
 from sparsezoo.analysis import ModelAnalysis
 
-
 __all__ = ["main"]
 
 
@@ -74,11 +73,9 @@ LOGGER = logging.getLogger()
 @click.option(
     "--save",
     default=None,
-    type=click.Path(
-        exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True
-    ),
+    type=click.Path(file_okay=True, dir_okay=False, readable=True, resolve_path=True),
     help="Path to a yaml file to write results to, note: file will be "
-    "overwritten if exists",
+         "overwritten if exists",
 )
 def main(model_path: str, save: Optional[str]):
     """
@@ -101,7 +98,7 @@ def main(model_path: str, save: Optional[str]):
     LOGGER.info("Analysis complete, collating results...")
 
     summary = analysis.summary()
-    summary["model_path"] = model_path
+    summary["Model"] = model_path
     pp.pprint(summary)
 
     if save:
@@ -121,5 +118,5 @@ def _get_model_file_path(model_path: str):
     return model_path
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR updates the summary printed by `sparsezoo.analyze` into a more human readable form:

```bash
sparsezoo.analyze "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none"
```

Output:

```bash
INFO:root:Downloading files from SparseZoo: 'zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none'
INFO:root:Starting Analysis ...
INFO:root:Analysis complete, collating results...
{   'Parameters': {   'Weight': {   'Total': 25502912,
                                    'Percent Total %': 100.0,
                                    'Sparsity %': 95.0,
                                    'FP32 Precision %': 100.0,
                                    'INT8 Precision %': 0.0},
                      'Bias': {   'Total': 1000,
                                  'Percent Total %': 0.0,
                                  'Sparsity %': 0.0,
                                  'FP32 Precision %': 100.0,
                                  'INT8 Precision %': 0.0},
                      'Total': {   'Total': 25503912,
                                   'Percent Total %': 100.0,
                                   'Sparsity %': 95.0,
                                   'FP32 Precision %': 100.0,
                                   'INT8 Precision %': 0.0}},
    'Parameterized Ops': {   'Conv': {   'Total': 23454912,
                                         'Percent Total %': 91.97,
                                         'Sparsity %': 95.66,
                                         'FP32 Precision %': 100.0,
                                         'INT8 Precision %': 0.0},
                             'Gemm': {   'Total': 2049000,
                                         'Percent Total %': 8.03,
                                         'Sparsity %': 87.42,
                                         'FP32 Precision %': 100.0,
                                         'INT8 Precision %': 0.0},
                             'Total': {   'Total': 25503912,
                                          'Percent Total %': 100.0,
                                          'Sparsity %': 95.0,
                                          'FP32 Precision %': 100.0,
                                          'INT8 Precision %': 0.0}},
    'Non Parameterized Ops': {   'Shape': {   'Total': 1,
                                              'Percent Total %': 0.79,
                                              'Sparsity %': 0.0,
                                              'FP32 Precision %': 100.0,
                                              'INT8 Precision %': 0.0},
                                 'GlobalAveragePool': {   'Total': 1,
                                                          'Percent Total %': 0.79,
                                                          'Sparsity %': 0.0,
                                                          'FP32 Precision %': 100.0,
                                                          'INT8 Precision %': 0.0},
                                 'Relu': {   'Total': 49,
                                             'Percent Total %': 38.58,
                                             'Sparsity %': 0.0,
                                             'FP32 Precision %': 100.0,
                                             'INT8 Precision %': 0.0},
                                 'Gather': {   'Total': 1,
                                               'Percent Total %': 0.79,
                                               'Sparsity %': 0.0,
                                               'FP32 Precision %': 100.0,
                                               'INT8 Precision %': 0.0},
                                 'Reshape': {   'Total': 1,
                                                'Percent Total %': 0.79,
                                                'Sparsity %': 0.0,
                                                'FP32 Precision %': 100.0,
                                                'INT8 Precision %': 0.0},
                                 'Add': {   'Total': 16,
                                            'Percent Total %': 12.6,
                                            'Sparsity %': 0.0,
                                            'FP32 Precision %': 100.0,
                                            'INT8 Precision %': 0.0},
                                 'BatchNormalization': {   'Total': 53,
                                                           'Percent Total %': 41.73,
                                                           'Sparsity %': 0.0,
                                                           'FP32 Precision %': 100.0,
                                                           'INT8 Precision %': 0.0},
                                 'Unsqueeze': {   'Total': 1,
                                                  'Percent Total %': 0.79,
                                                  'Sparsity %': 0.0,
                                                  'FP32 Precision %': 100.0,
                                                  'INT8 Precision %': 0.0},
                                 'MaxPool': {   'Total': 1,
                                                'Percent Total %': 0.79,
                                                'Sparsity %': 0.0,
                                                'FP32 Precision %': 100.0,
                                                'INT8 Precision %': 0.0},
                                 'Concat': {   'Total': 1,
                                               'Percent Total %': 0.79,
                                               'Sparsity %': 0.0,
                                               'FP32 Precision %': 100.0,
                                               'INT8 Precision %': 0.0},
                                 'Softmax': {   'Total': 1,
                                                'Percent Total %': 0.79,
                                                'Sparsity %': 0.0,
                                                'FP32 Precision %': 100.0,
                                                'INT8 Precision %': 0.0},
                                 'Constant': {   'Total': 1,
                                                 'Percent Total %': 0.79,
                                                 'Sparsity %': 0.0,
                                                 'FP32 Precision %': 100.0,
                                                 'INT8 Precision %': 0.0},
                                 'Total': {   'Total': 127,
                                              'Percent Total %': 100.0,
                                              'Sparsity %': 0.0,
                                              'FP32 Precision %': 100.0,
                                              'INT8 Precision %': 0.0}},
    'Summary': {   'Number of Parameters': 25503912,
                   'Number of Operations': 25504039,
                   'Weight Sparsity %': 95.0,
                   'Quantized Parameterized Ops %': 0.0,
                   'Quantized Non-Parameterized Ops %': 0.0},
    'Model': 'zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none'}
```