### PR TITLE
[Add] Emulation of `distutils.utils.strtobool` function in `sparsezoo`

### DIFF
--- a/src/sparsezoo/utils/helpers.py
+++ b/src/sparsezoo/utils/helpers.py
@@ -14,6 +14,7 @@
 
 import glob
 import os
+from types import MappingProxyType
 from typing import Any
 
 
@@ -23,13 +24,34 @@ __all__ = [
     "clean_path",
     "remove_tar_duplicates",
     "convert_to_bool",
+    "strtobool",
 ]
+
+# Read only mapping
+_STR_TO_BOOL_MAP: MappingProxyType = MappingProxyType(
+    {
+        "y": True,
+        "yes": True,
+        "t": True,
+        "true": True,
+        "on": True,
+        "1": True,
+        "n": False,
+        "no": False,
+        "f": False,
+        "false": False,
+        "off": False,
+        "0": False,
+    }
+)
 
 
 def convert_to_bool(val: Any):
     """
     :param val: a value
     :return: False if value is a Falsy value e.g. 0, f, false, None, otherwise True.
+        Note, use `sparsezoo.utils.strtobool` function for stricter checking of
+        Truthy values.
     """
     return (
         bool(val)
@@ -87,3 +109,17 @@ def clean_path(path: str) -> str:
     :return: a cleaned version that expands the user path and creates an absolute path
     """
     return os.path.abspath(os.path.expanduser(path))
+
+
+def strtobool(value: str) -> bool:
+    """
+    Emulation of distutils.strtobool since it is deprecated and will be removed
+    by Python3.12
+
+    :param value: a str value to be converted to bool
+    :returns: a bool representation of the value
+    """
+    try:
+        return _STR_TO_BOOL_MAP[value.lower()]
+    except KeyError:
+        raise ValueError('"{}" is not a valid bool value'.format(value))

--- a/tests/sparsezoo/utils/test_helpers.py
+++ b/tests/sparsezoo/utils/test_helpers.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from sparsezoo.utils.helpers import strtobool
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("1", True),
+        ("t", True),
+        ("T", True),
+        ("True", True),
+        ("f", False),
+        ("F", False),
+        ("False", False),
+        ("false", False),
+        ("Not True", ValueError()),
+        ("Not False", ValueError()),
+        (2, AttributeError()),
+        ({}, AttributeError()),
+        ([], AttributeError()),
+        (None, AttributeError()),
+    ],
+)
+def test_strtobool(value, expected):
+    if isinstance(expected, Exception):
+        with pytest.raises(expected.__class__):
+            strtobool(value)
+    else:
+        assert strtobool(value) == expected


### PR DESCRIPTION
This PR adds a `strtobool convenience ` function in `sparsezoo.utils.helpers`
module, the goal being to provide an emulation for the deprecated
`distutils.strtobool` function, this function has been deprecated since 
`Python3.10` and will be [removed](https://peps.python.org/pep-0632/#migration-advice) in `Python3.12`

The function is a rather convenient method, specially for accepting truthy/falsy
values, and the reason for putting it here is because `sparsezoo` is a base
dependecy accross all our repos namely `sparseml` and `deepsparse`

## Usage:

```python
>>> from sparsezoo.utils import strtobool
>>> strtobool("t")
True
>>> strtobool("True")
True
>>> strtobool("Not True")
Traceback (most recent call last):
  File "/home/ubuntu/projects/sparsezoo/src/sparsezoo/utils/helpers.py", line 123, in strtobool
    return _STR_TO_BOOL_MAP[str(value).lower()]
KeyError: 'not true'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3.9/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "/home/ubuntu/projects/sparsezoo/src/sparsezoo/utils/helpers.py", line 125, in strtobool
    raise ValueError('"{}" is not a valid bool value'.format(value))
ValueError: "Not True" is not a valid bool value
```

### CLI:

```python
import click
from sparsezoo.utils import strtobool

@click.command()
@click.option(
    "--dummy",
    type=str,
    required=True,
    callback=lambda ctx, params, value: strtobool(value)
)
def main(dummy):
    print(dummy)
```

### Tests:

Ran Manual Tests, and added Automated Tests