### PR TITLE
Conform Analyze CLI with PRD

### DIFF
--- a/src/sparsezoo/analyze/cli.py
+++ b/src/sparsezoo/analyze/cli.py
@@ -28,8 +28,12 @@ CONTEXT_SETTINGS = dict(
     allow_extra_args=True,
 )
 
+DEEPSPARSE_ENGINE = "deepsparse"
+ORT_ENGINE = "onnxruntime"
+SUPPORTED_ENGINES = [DEEPSPARSE_ENGINE, ORT_ENGINE]
 
-def analyze_options(command: callable):
+
+def analyze_options(command: click.Command):
     """
     A decorator that takes in a click command and adds analyze api options
     to it, this method is meant to be a single source of truth across all
@@ -46,13 +50,45 @@ def analyze_options(command: callable):
         required=True,
     )
     @click.option(
+        "--compare",
+        default=None,
+        type=str,
+        help="A multi-arg comma separated list of model paths to compare "
+        "against; can accept local path to an onnx model, a path to "
+        "deployment folder containing a onnx model, a SparseZoo stub, or a "
+        "previously run analysis yaml file. No comparision is run if omitted",
+    )
+    @click.option(
         "--save",
         default=None,
-        type=click.Path(
-            file_okay=True, dir_okay=False, readable=True, resolve_path=True
-        ),
-        help="Path to a yaml file to write results to, note: file will be "
-        "overwritten if exists",
+        type=str,
+        help="File path or directory to save the results as yaml to Note: file will be "
+        "overwritten if exists, if a directory path is passed results will be "
+        "stored under the directory as `analysis.yaml`, if set to True the file "
+        "will be saved under CWD as `analysis.yaml`",
+    )
+    @click.option(
+        "--save-graphs",
+        default=None,
+        type=str,
+        help="Directory to save the generated graphs to. if not specified "
+        "(default) no files will be saved. If set or boolean string, "
+        "saves the graphs in the CWD under `analysis-graphs`; If set as"
+        " directory path, graphs are saved in the specified directory",
+    )
+    @click.option(
+        "--by-types",
+        default=None,
+        type=str,
+        help="A flag to enable analysis results by operator type. If set or "
+        "boolean string, generates and records the results by operator type",
+    )
+    @click.option(
+        "--by-layer",
+        default=None,
+        type=str,
+        help="A flag to enable analysis results by layer type. If set or "
+        "boolean string, generates and records the results across all layers",
     )
     @functools.wraps(command)
     def wrap_common_options(*args, **kwargs):
@@ -62,3 +98,41 @@ def analyze_options(command: callable):
         return command(*args, **kwargs)
 
     return wrap_common_options
+
+
+def analyze_performance_options(command: click.Command):
+    """
+    A decorator that takes in a click command and adds analyze api performance
+    analysis options to it. This decorator can be directly imported and
+    used on top of another click command.
+
+    :param command: A click callable command
+    :return: The same click callable but with analyze api options attached
+    """
+
+    @click.option(
+        "--batch-size-latency",
+        default=1,
+        type=int,
+        help="The batch size to run latency benchmarks at",
+    )
+    @click.option(
+        "--batch-size-throughput",
+        default=1,
+        type=int,
+        help="The batch size to run throughput benchmarks at",
+    )
+    @click.option(
+        "--benchmark-engine",
+        default=DEEPSPARSE_ENGINE,
+        type=click.Choice(SUPPORTED_ENGINES, case_sensitive=False),
+        help="The engine to run the benchmarks through",
+    )
+    @functools.wraps(command)
+    def wrap_with_performance_options(*args, **kwargs):
+        """
+        Wrapper that adds analyze performance options to command
+        """
+        return command(*args, **kwargs)
+
+    return wrap_with_performance_options

--- a/src/sparsezoo/analyze/cli.py
+++ b/src/sparsezoo/analyze/cli.py
@@ -117,6 +117,22 @@ def analyze_performance_options(command: click.Command):
         help="The batch size to run latency benchmarks at",
     )
     @click.option(
+        "--impose",
+        default=None,
+        type=str,
+        help="The sparsification options to impose on the model and run as a "
+        "comparison; this is a multi arg list of any of the following, "
+        "`sparse` or `pruned` to set the sparsity for all prunable layers to 85%,"
+        " #.## a float [0,1] to set the sparsity for all prunable layers to, "
+        "`quant` or `quantized` to enable quantization with int8 activations "
+        "and weights for all quantizable layers, {precision} to enable "
+        "quantization with {precision: int16, int8, int4, int2} activations and "
+        "weights for all quantizable layers w_{precision} to enable quantization"
+        " with {precision: int16, int8, int4, int2} weights for all quantizable "
+        "layers a_{precision} to enable quantization with {precision: int16, "
+        "int8, int4, int2} activations for all quantizable layers",
+    )
+    @click.option(
         "--batch-size-throughput",
         default=1,
         type=int,

--- a/src/sparsezoo/analyze_cli.py
+++ b/src/sparsezoo/analyze_cli.py
@@ -27,10 +27,28 @@ Usage: sparsezoo.analyze [OPTIONS] MODEL_PATH
       sparsezoo.analyze ~/models/resnet50.onnx
 
 Options:
-  --save FILE  Path to a yaml file to write results to, note: file will be
-               overwritten if exists
-  --help       Show this message and exit.
-
+  --compare TEXT      A multi-arg comma separated list of model paths to
+                      compare against; can accept local path to an onnx model,
+                      a path to deployment folder containing a onnx model, a
+                      SparseZoo stub, or a previously run analysis yaml file.
+                      No comparision is run if omitted
+  --save TEXT         File path or directory to save the results as yaml to
+                      Note: file will be overwritten if exists, if a directory
+                      path is passed results will be stored under the
+                      directory as `analysis.yaml`, if set to True the file
+                      will be saved under CWD as `analysis.yaml`
+  --save-graphs TEXT  Directory to save the generated graphs to. if not
+                      specified (default) no files will be saved. If set or
+                      boolean string, saves the graphs in the CWD under
+                      `analysis-graphs`; If set as directory path, graphs are
+                      saved in the specified directory
+  --by-types TEXT     A flag to enable analysis results by operator type. If
+                      set or boolean string, generates and records the results
+                      by operator type
+  --by-layer TEXT     A flag to enable analysis results by layer type. If set
+                      or boolean string, generates and records the results
+                      across all layers
+  --help              Show this message and exit.
 ##########
 Examples:
 1) Model Analysis on Resnet50

--- a/src/sparsezoo/analyze_cli.py
+++ b/src/sparsezoo/analyze_cli.py
@@ -62,7 +62,7 @@ LOGGER = logging.getLogger()
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @analyze_options
-def main(model_path: str, save: Optional[str]):
+def main(model_path: str, save: Optional[str], **kwargs):
     """
     Model analysis for ONNX models.
 
@@ -76,6 +76,13 @@ def main(model_path: str, save: Optional[str]):
         sparsezoo.analyze ~/models/resnet50.onnx
     """
     logging.basicConfig(level=logging.INFO)
+
+    for unimplemented_feat in ("compare", "by_layer", "by_types", "save_graphs"):
+        if kwargs.get(unimplemented_feat):
+            raise NotImplementedError(
+                f"--{unimplemented_feat} has not been implemented yet"
+            )
+
     model_file_path = _get_model_file_path(model_path=model_path)
 
     LOGGER.info("Starting Analysis ...")


### PR DESCRIPTION
This PR accomplishes the following:

- Conforms `sparsezoo.analyze` cli with requirements from PRD
- Adds performance benchmark related options as a separate decorator that can be chained with existing `click.Command`, [Useful for `deepsparse.analyze` and `sparseml.analyze`]
- Raises `NotImplementedError` for unimplemented features

Arg requirements from PRD:

```
MODEL: The model or previous analysis file to load/display analysis results for
- Path to an ONNX model
- Path to a deployment folder containing an ONNX model
- SparseZoo stub
- Path to a previous analysis.yaml file
compare: The model(s) or previous analysis file(s) to load/display comparison results to FILE
- None (default) to not display any comparison
- A multi arg list of any of the following
- Path to an ONNX model
- Path to a deployment folder containing an ONNX model
- SparseZoo stub
- Path to a previous analysis.yaml file
save: File path or directory to save the results as yaml to
- Unset (default) to not save any files
- If set or boolean string, save the file in the CWD under analysis.yaml
- If set as a directory path, save the file in the directory under analysis.yaml
- If set as a file path, save the file at that path
save-graphs: Directory to save the generated graphs to
- Unset (default) to not save any files
- If set or boolean string, saves the graphs in the CWD under analysis-graphs/
- If set as directory path, save the graphs in the directory
by-types: A flag to enable analysis results by operator type
- Unset (default) to not generate any results by type
- If set or boolean string, generates and records the results by operator type
by-layers: A flag to enable analysis results by layer type
- Unset (default) to not generate any results by layer type
- If set or boolean string, generates and records the results across all layers
```

Test: `sparsezoo.analyze --help`
```bash
Usage: sparsezoo.analyze [OPTIONS] MODEL_PATH

  Model analysis for ONNX models.

  MODEL_PATH: can be a SparseZoo stub, or local path to a deployment-directory
  or ONNX model

  Examples:

  - Run model analysis on resnet

      sparsezoo.analyze ~/models/resnet50.onnx

Options:
  --compare TEXT      A multi-arg comma separated list of model paths to
                      compare against; can accept local path to an onnx model,
                      a path to deployment folder containing a onnx model, a
                      SparseZoo stub, or a previously run analysis yaml file.
                      No comparision is run if omitted
  --save TEXT         File path or directory to save the results as yaml to
                      Note: file will be overwritten if exists, if a directory
                      path is passed results will be stored under the
                      directory as `analysis.yaml`, if set to True the file
                      will be saved under CWD as `analysis.yaml`
  --save-graphs TEXT  Directory to save the generated graphs to. if not
                      specified (default) no files will be saved. If set or
                      boolean string, saves the graphs in the CWD under
                      `analysis-graphs`; If set as directory path, graphs are
                      saved in the specified directory
  --by-types TEXT     A flag to enable analysis results by operator type. If
                      set or boolean string, generates and records the results
                      by operator type
  --by-layer TEXT     A flag to enable analysis results by layer type. If set
                      or boolean string, generates and records the results
                      across all layers
  --help              Show this message and exit.
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204202998291952