### PR TITLE
error handling - send message from graphql

### DIFF
--- a/src/sparsezoo/api/__init__.py
+++ b/src/sparsezoo/api/__init__.py
@@ -14,6 +14,7 @@
 
 # flake8: noqa
 
+from .exceptions import *
 from .graphql import *
 from .query_parser import *
 from .utils import *

--- a/src/sparsezoo/api/exceptions.py
+++ b/src/sparsezoo/api/exceptions.py
@@ -24,8 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 class InvalidQueryValueError(Exception):
-    def __init__(self, message: Optional[str] = None, *args, **kwargs):
-        error_message = f"{message}" if message else message
+    def __init__(self, error_message: Optional[str] = None, *args, **kwargs):
         super().__init__(
             error_message,
             *args,
@@ -53,4 +52,6 @@ def validate_graphql_response(response: Response, query_body: str) -> None:
     response_json = response.json()
 
     if response_json.get("data") is None and "errors" in response_json:
-        raise InvalidQueryValueError(message=f"{response_json['errors']}\n{query_body}")
+        raise InvalidQueryValueError(
+            error_message=f"{response_json['errors']}\n{query_body}"
+        )

--- a/src/sparsezoo/api/exceptions.py
+++ b/src/sparsezoo/api/exceptions.py
@@ -42,5 +42,5 @@ def validate_graphql_response(response: Response, query_body: str) -> None:
     response.raise_for_status()
     response_json = response.json()
 
-    if response_json.get("data") is None and "errors" in response_json:
+    if "errors" in response_json:
         raise InvalidQueryException(f"{response_json['errors']}\n{query_body}")

--- a/src/sparsezoo/api/exceptions.py
+++ b/src/sparsezoo/api/exceptions.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from functools import wraps
+from typing import Callable, Optional
+
+from requests.exceptions import HTTPError
+from requests.models import Response
+
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidQueryValueError(Exception):
+    def __init__(self, message: Optional[str] = None, *args, **kwargs):
+        error_message = f"{message}" if message else message
+        super().__init__(
+            error_message,
+            *args,
+            **kwargs,
+        )
+
+
+def graphqlapi_exception_handler(fn: Callable) -> Callable:
+    @wraps(fn)
+    def inner_function(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+
+        except HTTPError as _err:
+            logger.error(f"request exception: {_err}")
+
+        except InvalidQueryValueError as _err:
+            logger.error(f"InvalidQueryValueError: {_err}")
+
+    return inner_function
+
+
+def validate_graphql_response(response: Response, query_body: str) -> None:
+    response.raise_for_status()
+    response_json = response.json()
+
+    if response_json.get("data") is None and "errors" in response_json:
+        raise InvalidQueryValueError(message=f"{response_json['errors']}\n{query_body}")

--- a/src/sparsezoo/api/graphql.py
+++ b/src/sparsezoo/api/graphql.py
@@ -19,6 +19,7 @@ import requests
 
 from sparsezoo.utils import BASE_API_URL
 
+from .exceptions import graphqlapi_exception_handler, validate_graphql_response
 from .query_parser import QueryParser
 from .utils import map_keys, to_snake_case
 
@@ -55,6 +56,7 @@ class GraphQLAPI:
             for response_object in response_objects
         ]
 
+    @graphqlapi_exception_handler
     def make_request(
         self,
         operation_body: str,
@@ -76,7 +78,7 @@ class GraphQLAPI:
             url=url or f"{BASE_API_URL}/v2/graphql", json={"query": query.query_body}
         )
 
-        response.raise_for_status()
+        validate_graphql_response(response=response, query_body=query.query_body)
         response_json = response.json()
 
         return response_json["data"][query.operation_body]

--- a/tests/sparsezoo/api/test_exception.py
+++ b/tests/sparsezoo/api/test_exception.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict
+from unittest.mock import MagicMock
+
 import pytest
 
 from sparsezoo.api.exceptions import InvalidQueryException, validate_graphql_response
@@ -38,33 +41,43 @@ def test_invalid_query_exception():
     }
 
 
-@pytest.mark.xfail(raises=InvalidQueryException)
 @pytest.mark.parametrize(
-    "response",
-    {
-        "ddata": [
+    "should_raise_invalid_query_exception,response",
+    [
+        (
+            True,
             {
-                "message": "Cannot query field 'blah' on type 'Query'.",
-                "locations": [{"line": 3, "column": 9}],
-            }
-        ],
-    },
-    {
-        "ddata": [
+                "data": None,
+                "errors": {
+                    "message": "Cannot query field 'blah' on type 'Query'.",
+                    "locations": [{"line": 3, "column": 9}],
+                },
+            },
+        ),
+        (
+            True,
             {
-                "message": "Cannot query field 'blah' on type 'Query'.",
-                "locations": [{"line": 3, "column": 9}],
-            }
-        ],
-    },
-    {
-        "ddata": [
+                "data": None,
+                "errors": {
+                    "message": "Cannot query field 'foo' on type 'Query'.",
+                    "locations": [{"line": 5, "column": 9}],
+                },
+            },
+        ),
+        (
+            False,
             {
-                "message": "Cannot query field 'blah' on type 'Query'.",
-                "locations": [{"line": 3, "column": 9}],
-            }
-        ],
-    },
+                "data": "foo",
+            },
+        ),
+    ],
 )
-def test_whatever(response):
-    validate_graphql_response(response)
+def test_whatever(should_raise_invalid_query_exception: bool, response: Dict):
+    mock_response = MagicMock()
+    mock_response.json.return_value = response
+
+    if should_raise_invalid_query_exception:
+        with pytest.raises(InvalidQueryException):
+            validate_graphql_response(mock_response, "")
+    else:
+        validate_graphql_response(mock_response, "")

--- a/tests/sparsezoo/api/test_exception.py
+++ b/tests/sparsezoo/api/test_exception.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from sparsezoo.api.exceptions import InvalidQueryException, validate_graphql_response
+
+
+@pytest.fixture
+def test_invalid_query_exception():
+    return {
+        "data": [
+            {
+                "message": "Cannot query field 'blah' on type 'Query'.",
+                "locations": [{"line": 3, "column": 9}],
+            }
+        ],
+        "camel_case_list": [
+            "sparseTag",
+            "subDomain",
+            "tokenClassification",
+            "baseCased",
+            "modelId",
+            "displayName",
+            "modelOnnxSizeCompressedBytes",
+        ],
+    }
+
+
+@pytest.mark.xfail(raises=InvalidQueryException)
+@pytest.mark.parametrize(
+    "response",
+    {
+        "ddata": [
+            {
+                "message": "Cannot query field 'blah' on type 'Query'.",
+                "locations": [{"line": 3, "column": 9}],
+            }
+        ],
+    },
+    {
+        "ddata": [
+            {
+                "message": "Cannot query field 'blah' on type 'Query'.",
+                "locations": [{"line": 3, "column": 9}],
+            }
+        ],
+    },
+    {
+        "ddata": [
+            {
+                "message": "Cannot query field 'blah' on type 'Query'.",
+                "locations": [{"line": 3, "column": 9}],
+            }
+        ],
+    },
+)
+def test_whatever(response):
+    validate_graphql_response(response)

--- a/tests/sparsezoo/api/test_exception.py
+++ b/tests/sparsezoo/api/test_exception.py
@@ -20,27 +20,6 @@ import pytest
 from sparsezoo.api.exceptions import InvalidQueryException, validate_graphql_response
 
 
-@pytest.fixture
-def test_invalid_query_exception():
-    return {
-        "data": [
-            {
-                "message": "Cannot query field 'blah' on type 'Query'.",
-                "locations": [{"line": 3, "column": 9}],
-            }
-        ],
-        "camel_case_list": [
-            "sparseTag",
-            "subDomain",
-            "tokenClassification",
-            "baseCased",
-            "modelId",
-            "displayName",
-            "modelOnnxSizeCompressedBytes",
-        ],
-    }
-
-
 @pytest.mark.parametrize(
     "should_raise_invalid_query_exception,response",
     [

--- a/tests/sparsezoo/api/test_exception.py
+++ b/tests/sparsezoo/api/test_exception.py
@@ -51,7 +51,9 @@ from sparsezoo.api.exceptions import InvalidQueryException, validate_graphql_res
         ),
     ],
 )
-def test_whatever(should_raise_invalid_query_exception: bool, response: Dict):
+def test_graphql_error_response(
+    should_raise_invalid_query_exception: bool, response: Dict
+):
     mock_response = MagicMock()
     mock_response.json.return_value = response
 


### PR DESCRIPTION
Before:
```
(.venv) george@Georges-MacBook-Pro sparsezoo % python3 '/Users/george/neuralmagic/sparsezoo/scratch/graohql.py'
Traceback (most recent call last):
  File "/Users/george/neuralmagic/sparsezoo/scratch/graohql.py", line 15, in <module>
    m = gql.fetch(operation_body=operation_body, fields=fields, arguments=arguments)
  File "/Users/george/neuralmagic/sparsezoo/src/sparsezoo/api/graphql.py", line 46, in fetch
    response_objects = self.make_request(
  File "/Users/george/neuralmagic/sparsezoo/src/sparsezoo/api/graphql.py", line 82, in make_request
    return response_json["data"][query.operation_body]
TypeError: 'NoneType' object is not subscriptable
```

After:
```
Traceback (most recent call last):
  File "/Users/george/neuralmagic/sparsezoo/scratch/graohql.py", line 15, in <module>
    m = gql.fetch(operation_body=operation_body, fields=fields, arguments=arguments)
  File "/Users/george/neuralmagic/sparsezoo/src/sparsezoo/api/graphql.py", line 47, in fetch
    response_objects = self.make_request(
  File "/Users/george/neuralmagic/sparsezoo/src/sparsezoo/api/exceptions.py", line 33, in inner_function
    return fn(*args, **kwargs)
  File "/Users/george/neuralmagic/sparsezoo/src/sparsezoo/api/graphql.py", line 81, in make_request
    validate_graphql_response(response=response, query_body=query.query_body)
  File "/Users/george/neuralmagic/sparsezoo/src/sparsezoo/api/exceptions.py", line 46, in validate_graphql_response
    raise InvalidQueryException(f"{response_json['errors']}\n{query_body}")
sparsezoo.api.exceptions.InvalidQueryException: [{'message': "Cannot query field 'blah' on type 'Query'.", 'locations': [{'line': 3, 'column': 9}]}]

    {
        blah (architecture: "bert",)
            {
               benchmarkResults { batchSize deviceInfo numCores recordedUnits recordedValue } 
            }
    }

```