### PR TITLE
Early exit if NM_DISABLE_ANALYTICS is set

### DIFF
--- a/src/sparsezoo/analytics.py
+++ b/src/sparsezoo/analytics.py
@@ -38,10 +38,9 @@ def analytics_disabled():
     """
     :return: True if analytics should be disabled, False otherwise
     """
-    gdpr = is_gdpr_country()
     env_disabled = os.getenv("NM_DISABLE_ANALYTICS")
 
-    return gdpr or env_disabled
+    return env_disabled or is_gdpr_country()
 
 
 class GoogleAnalytics:


### PR DESCRIPTION
analytics_disabled() was always doing the country check before checking the NM_DISABLE_ANALYTICS env variable, e.g.
```
2023-04-04 22:00:19,003 [MainThread  ] [INFO ]  Requested http://ipinfo.io/199.217.107.238/json
2023-04-04 22:00:19,397 [MainThread  ] [INFO ]  Requested http://ipinfo.io/199.217.107.238/json
```
This checks the env variable before checking the country.