### PR TITLE
[analytics] disable in make test and GHA tests, unit test to always check send_event

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SPARSEZOO_TEST_MODE: "true"
+      NM_DISABLE_ANALYTICS: "true"
     needs: test-setup
     if: ${{needs.test-setup.outputs.python-diff == 1}}
     steps:
@@ -46,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SPARSEZOO_TEST_MODE: "true"
+      NM_DISABLE_ANALYTICS: "true"
     needs: test-setup
     if: ${{needs.test-setup.outputs.full-check == 1}}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ style:
 # run tests for the repo
 test:
 	@echo "Running python tests";
-	SPARSEZOO_TEST_MODE="true" pytest tests $(PYTEST_ARGS);
+	SPARSEZOO_TEST_MODE="true" NM_DISABLE_ANALYTICS="true" pytest tests $(PYTEST_ARGS);
 
 # create docs
 docs:

--- a/src/sparsezoo/analytics.py
+++ b/src/sparsezoo/analytics.py
@@ -106,6 +106,7 @@ class GoogleAnalytics:
         event_name: str,
         event_params: Optional[Dict[str, str]] = None,
         raise_errors: bool = False,
+        _await_response: bool = False,
     ):
         """
         Send an event
@@ -113,8 +114,14 @@ class GoogleAnalytics:
         :param event_name: the name of the event to send
         :param event_params: optional dictionary of parameters to send with the event
         :param raise_errors: True to raise any errors that occur, False otherwise
+        :param _await_response: (testing only) True to wait for analytics request
+            thread to complete before returning. Default False
         """
         if self._disabled:
+            if _await_response:
+                raise ValueError(
+                    "_await_response cannot be set to True when analytics is disabled"
+                )
             return
 
         if not event_params:
@@ -148,6 +155,9 @@ class GoogleAnalytics:
 
         thread = threading.Thread(target=_send_request)
         thread.start()
+
+        if _await_response:
+            thread.join()
 
 
 # analytics client for sparsezoo, to disable set NM_DISABLE_ANALYTICS=1

--- a/tests/sparsezoo/test_analytics.py
+++ b/tests/sparsezoo/test_analytics.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from copy import deepcopy
+
+from sparsezoo.analytics import sparsezoo_analytics
+
+
+def test_send_event_success():
+    test_analytics = deepcopy(sparsezoo_analytics)
+    test_analytics._disabled = False
+
+    test_analytics.send_event(
+        "tests__analytics__test_send_event_success",
+        raise_errors=True,
+        _await_response=True,
+    )


### PR DESCRIPTION
adds env var to disable analytics calls in GHA tests and `make test`

adds unit test to override the disable and verify a simple `send_event` call. add pathway to ensure that analytics thread completes

**test_plan:**
* unit tests included
* @markurtz to verify GHA no longer triggers GA calls