### PR TITLE
Fix - error in f-string 

### DIFF
--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -168,9 +168,7 @@ class File:
                 logging.error(err)
                 logging.error(traceback.format_exc())
                 time.sleep(retry_sleep_sec)
-            logging.error(
-                f"Trying attempt {attempt + 1} of {retries}.", attempt + 1, retries
-            )
+            logging.error(f"Trying attempt {attempt + 1} of {retries}.")
         logging.error("Download retry failed...")
         raise Exception("Exceed max retry attempts: {} failed".format(retries))
 


### PR DESCRIPTION
Erroneously mixed s-string with f-string.

After this fix the error message is as expected:
```bash
        logging.error("Download retry failed...")
>       raise Exception("Exceed max retry attempts: {} failed".format(retries))
E       Exception: Exceed max retry attempts: 1 failed
```

