### PR TITLE
Connect Deepsparse.Analyze

### DIFF
--- a/src/sparsezoo/analyze/analysis.py
+++ b/src/sparsezoo/analyze/analysis.py
@@ -825,7 +825,7 @@ class ModelAnalysisSummary(Entry, YAMLSerializableBaseModel):
                 section_name="Overall",
                 entries=[
                     PerformanceEntry(
-                        model=idx,
+                        model=analysis.model_name,
                         sparsity=overall_count_summary.sparsity_percent,
                         quantized=overall_count_summary.quantized_percent,
                         latency=benchmark_result.average_latency,

--- a/src/sparsezoo/analyze/analysis.py
+++ b/src/sparsezoo/analyze/analysis.py
@@ -268,6 +268,11 @@ class BenchmarkResult(YAMLSerializableBaseModel):
         description="Node level inference results",
     )
 
+    supported_graph_percentage: Optional[float] = Field(
+        default=None,
+        description="Percentage of model graph supported by the runtime engine"
+    )
+
 
 class NodeAnalysis(YAMLSerializableBaseModel):
     """
@@ -830,7 +835,10 @@ class ModelAnalysisSummary(Entry, YAMLSerializableBaseModel):
                         quantized=overall_count_summary.quantized_percent,
                         latency=benchmark_result.average_latency,
                         throughput=benchmark_result.items_per_second,
-                        supported_graph=0.0,  # TODO: fill in correct value
+                        supported_graph=(
+                                benchmark_result.supported_graph_percentage
+                                or 0.0
+                        ),
                     )
                     for idx, benchmark_result in enumerate(analysis.benchmark_results)
                 ],

--- a/src/sparsezoo/analyze/utils/models.py
+++ b/src/sparsezoo/analyze/utils/models.py
@@ -374,7 +374,16 @@ class Section(Entry):
     Represents a list of Entries with an optional name
     """
 
-    entries: List[Union[NamedEntry, TypedEntry, SizedModelEntry, ModelEntry, BaseEntry]]
+    entries: List[
+        Union[
+            PerformanceEntry,
+            NamedEntry,
+            TypedEntry,
+            SizedModelEntry,
+            ModelEntry,
+            BaseEntry,
+        ]
+    ]
 
     section_name: str = ""
 

--- a/src/sparsezoo/analyze/utils/models.py
+++ b/src/sparsezoo/analyze/utils/models.py
@@ -369,6 +369,20 @@ class PerformanceEntry(BaseEntry):
     ] + BaseEntry._print_order
 
 
+class NodeTimingEntry(Entry):
+    """
+    A BaseEntry with additional performance info
+    """
+
+    node_name: str
+    avg_runtime: float
+
+    _print_order = [
+        "node_name",
+        "avg_runtime",
+    ] + Entry._print_order
+
+
 class Section(Entry):
     """
     Represents a list of Entries with an optional name
@@ -376,6 +390,7 @@ class Section(Entry):
 
     entries: List[
         Union[
+            NodeTimingEntry,
             PerformanceEntry,
             NamedEntry,
             TypedEntry,
@@ -434,7 +449,7 @@ class Section(Entry):
     def get_comparable_entries(self, other: "Section") -> Tuple[List[Entry], ...]:
         """
         Get comparable entries by same name or type if they belong to
-        `NamedEntry` or `TypedEntry`, else return all entries
+        `NamedEntry`, `TypedEntry`, or `NodeTimingEntry`, else return all entries
 
         :return: A tuple composed of two lists, containing comparable entries
             in correct order from current and other Section objects
@@ -443,6 +458,7 @@ class Section(Entry):
         entry_type_to_extractor = {
             "NamedEntry": lambda entry: entry.name,
             "TypedEntry": lambda entry: entry.type,
+            "NodeTimingEntry": lambda entry: entry.node_name,
         }
         entry_type = self.entries[0].__class__.__name__
 

--- a/src/sparsezoo/analyze/utils/models.py
+++ b/src/sparsezoo/analyze/utils/models.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import Dict, List, Optional, Union, Tuple
+import textwrap
+from typing import Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field
 
@@ -272,30 +273,26 @@ class Entry(BaseModel):
 
         return self.__class__(**new_fields)
 
-    def pretty_print(self, headers: bool = False):
+    def pretty_print(self, headers: bool = False, column_width=30):
         """
         pretty print current Entry object with all it's fields
         """
-        column_width = 15
         field_names = self._print_order
         field_values = []
         for field_name in field_names:
             field_value = getattr(self, field_name)
             if isinstance(field_value, float):
                 field_value = f"{field_value:.2f}"
-            if field_name == "model":
-                field_value = field_value[-40:]
             field_values.append(field_value)
-
-        column_fmt = "{{:>{0}}} ".format(column_width)
-        fmt_string = "{:>40}" + (column_fmt * (len(field_names) - 1))
 
         if headers:
             print(
-                fmt_string.format(*(field_name.upper() for field_name in field_names))
+                multiline_pretty_print(
+                    row=[field_name.upper() for field_name in field_names],
+                    column_width=column_width,
+                )
             )
-
-        print(fmt_string.format(*field_values))
+        print(multiline_pretty_print(row=field_values, column_width=column_width))
 
 
 class BaseEntry(Entry):
@@ -425,7 +422,7 @@ class Section(Entry):
             entries=compared_entries,
         )
 
-    def get_comparable_entries(self, other: "Section")-> Tuple[List[Entry], ...]:
+    def get_comparable_entries(self, other: "Section") -> Tuple[List[Entry], ...]:
         """
         Get comparable entries by same name or type if they belong to
         `NamedEntry` or `TypedEntry`, else return all entries
@@ -461,3 +458,32 @@ class Section(Entry):
                 f"comparison in Section: {self.section_name}"
             )
         return self_comparable_entries, other_comparable_entries
+
+
+def multiline_pretty_print(row: List[str], column_width=20) -> str:
+    """
+    Formats the contents of the specified row into a multiline string which
+    each column is wrapped into a multiline string if its length is greater
+    than the specified column_width
+
+    :param row: A list of strings to be formatted into a multiline row
+    :param column_width: The max width of each column for formatting, default is 20
+    :returns: A multiline formatted string representing the row,
+    """
+    row = [str(column) for column in row]
+    result_string = ""
+    col_delim = " "
+    wrapped_row = [textwrap.wrap(col, column_width) for col in row]
+    max_lines_needed = max(len(col) for col in wrapped_row)
+
+    for line_idx in range(max_lines_needed):
+        result_string += col_delim
+        for column in wrapped_row:
+            if line_idx < len(column):
+                result_string += column[line_idx].ljust(column_width)
+            else:
+                result_string += " " * column_width
+            result_string += col_delim
+        if line_idx < max_lines_needed - 1:
+            result_string += "\n"
+    return result_string

--- a/src/sparsezoo/analyze/utils/models.py
+++ b/src/sparsezoo/analyze/utils/models.py
@@ -402,7 +402,7 @@ class Section(Entry):
             )
 
         section_name = self.section_name or ""
-        self_entries, other_entries = self._get_entries_to_compare(other)
+        self_entries, other_entries = self._get_comparable_entries(other)
 
         compared_entries = [
             self_entry - other_entry
@@ -414,7 +414,7 @@ class Section(Entry):
             entries=compared_entries,
         )
 
-    def _get_entries_to_compare(self, other: "Section"):
+    def _get_comparable_entries(self, other: "Section"):
         assert self.entries
         entry_type_to_extractor = {
             "NamedEntry": lambda entry: entry.name,

--- a/src/sparsezoo/analyze_cli.py
+++ b/src/sparsezoo/analyze_cli.py
@@ -72,7 +72,7 @@ from sparsezoo.analyze.cli import CONTEXT_SETTINGS, analyze_options
 __all__ = ["main"]
 
 
-LOGGER = logging.getLogger()
+_LOGGER = logging.getLogger(__name__)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -106,9 +106,9 @@ def main(
                 f"--{unimplemented_feat} has not been implemented yet"
             )
 
-    LOGGER.info("Starting Analysis ...")
+    _LOGGER.info("Starting Analysis ...")
     analysis = ModelAnalysis.create(model_path)
-    LOGGER.info("Analysis complete, collating results...")
+    _LOGGER.info("Analysis complete, collating results...")
 
     by_types: bool = convert_to_bool(by_types)
     by_layers: bool = convert_to_bool(by_layers)
@@ -125,18 +125,20 @@ def main(
         else:
             compare = [compare]
 
-        print("Comparision Results")
+        print("Comparison Analysis!!!")
         for model_to_compare in compare:
             compare_model_analysis = ModelAnalysis.create(model_to_compare)
             summary_comparison_model = compare_model_analysis.summary(
                 by_types=by_types,
                 by_layers=by_layers,
             )
+            print(f"Comparing {model_path} with {model_to_compare}")
+            print("Note: comparison analysis displays differences b/w models")
             comparison = summary - summary_comparison_model
             comparison.pretty_print()
 
     if save:
-        LOGGER.info(f"Writing results to {save}")
+        _LOGGER.info(f"Writing results to {save}")
         analysis.yaml(file_path=save)
 
 


### PR DESCRIPTION
This PR will represent all the changes needed to connect 
`deepsparse.analyze` with `sparsezoo.analyze`


Some Notable Changes include:
* Add: `PerformanceEntry` to entry types, else it will be converted to a `ModelEntry`
* Fix: `model_name` while instantiating `PerformanceEntry`
* Add: Node level timings


```bash
deepsparse.analyze \
  "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_uniform_quant-none" \
  --by-layers True \
  --by-types True \
  --compare "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_quant-none" 
```

```bash
(deepsparse3.8) 🥃 deepsparse deepsparse.analyze \
  "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_uniform_quant-none" \
  --by-layers True \
  --by-types True \
  --compare "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_quant-none"
2023-04-14 08:42:02 deepsparse.analyze INFO     Starting Analysis ...
INFO:deepsparse.analyze:Starting Analysis ...
2023-04-14 08:42:03 deepsparse.analyze INFO     Analysis complete, collating results...
INFO:deepsparse.analyze:Analysis complete, collating results...
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.5.0.20230303 COMMUNITY | () (release) (optimized) (system=avx512, binary=avx512)
[7fe5b6ffd700 >WARN<  operator() ./src/include/wand/utility/warnings.hpp:14] Generating emulated code for quantized (INT8) operations since no VNNI instructions were detected. Set NM_FAST_VNNI_EMULATION=1 to increase performance at the expense of accuracy.
INFO:root:Running analysis `by_layers`
INFO:root:Running analysis `by_types`
Analysis by Layers:
 NAME                           TOTAL                          SIZE                           SPARSITY                       QUANTIZED
 Conv_13_quant                  9472.00                        58679                          24.10                          99.32
 Conv_37_quant                  4160.00                        2252                           93.53                          98.46
 Conv_105_quant                 16640.00                       8982                           93.55                          98.46
 Conv_60_quant                  36928.00                       15234                          94.87                          99.83
 Conv_83_quant                  16640.00                       8912                           93.60                          98.46
 Conv_129_quant                 16448.00                       7148                           94.63                          99.61
 Conv_152_quant                 36928.00                       15293                          94.85                          99.83
 Conv_175_quant                 16640.00                       8968                           93.56                          98.46
 Conv_199_quant                 16448.00                       7135                           94.64                          99.61
 Conv_222_quant                 36928.00                       15293                          94.85                          99.83
 Conv_245_quant                 16640.00                       8898                           93.61                          98.46
 Conv_269_quant                 32896.00                       14270                          94.64                          99.61
 Conv_337_quant                 131584.00                      54951                          94.84                          99.61
 Conv_292_quant                 147584.00                      60015                          94.93                          99.91
 Conv_315_quant                 66048.00                       30872                          94.29                          99.22
 Conv_361_quant                 65664.00                       26789                          94.93                          99.81
 Conv_384_quant                 147584.00                      59660                          94.96                          99.91
 Conv_407_quant                 66048.00                       30764                          94.31                          99.22
 Conv_431_quant                 65664.00                       27264                          94.84                          99.81
 Conv_454_quant                 147584.00                      59779                          94.95                          99.91
 Conv_477_quant                 66048.00                       30926                          94.28                          99.22
 Conv_501_quant                 65664.00                       27264                          94.84                          99.81
 Conv_524_quant                 147584.00                      60015                          94.93                          99.91
 Conv_547_quant                 66048.00                       30926                          94.28                          99.22
 Conv_571_quant                 131328.00                      54740                          94.82                          99.81
 Conv_639_quant                 525312.00                      216426                         94.88                          99.81
 Conv_594_quant                 590080.00                      236811                         94.99                          99.96
 Conv_617_quant                 263168.00                      114163                         94.64                          99.61
 Conv_663_quant                 262400.00                      105477                         94.99                          99.90
 Conv_686_quant                 590080.00                      236339                         95.00                          99.96
 Conv_709_quant                 263168.00                      113737                         94.66                          99.61
 Conv_733_quant                 262400.00                      105267                         95.00                          99.90
 Conv_756_quant                 590080.00                      237284                         94.98                          99.96
 Conv_779_quant                 263168.00                      113524                         94.67                          99.61
 Conv_803_quant                 262400.00                      106319                         94.95                          99.90
 Conv_826_quant                 590080.00                      237284                         94.98                          99.96
 Conv_849_quant                 263168.00                      113737                         94.66                          99.61
 Conv_873_quant                 262400.00                      106319                         94.95                          99.90
 Conv_896_quant                 590080.00                      236811                         94.99                          99.96
 Conv_919_quant                 263168.00                      113737                         94.66                          99.61
 Conv_943_quant                 262400.00                      106530                         94.94                          99.90
 Conv_966_quant                 590080.00                      237284                         94.98                          99.96
 Conv_989_quant                 263168.00                      113737                         94.66                          99.61
 Conv_1013_quant                524800.00                      214324                         94.91                          99.90
 Conv_1081_quant                2099200.00                     838769                         95.02                          99.90
 Conv_1036_quant                2359808.00                     940759                         95.02                          99.98
 Conv_1059_quant                1050624.00                     436233                         94.84                          99.81
 Conv_1105_quant                1049088.00                     421930                         94.98                          99.95
 Conv_1128_quant                2359808.00                     942648                         95.01                          99.98
 Conv_1151_quant                1050624.00                     434543                         94.86                          99.81
 Conv_1175_quant                1049088.00                     422771                         94.97                          99.95
 Conv_1198_quant                2359808.00                     946426                         94.99                          99.98
 Conv_1221_quant                1050624.00                     436233                         94.84                          99.81
 Gemm_1239                      2049000.00                     65568000                       0.00                           0.00

Parameters by types:
 TYPE                           SIZE                           SPARSITY                       QUANTIZED
 Weight                         31950722                       87.38                          91.97
 Bias                           881920                         0.00                           0.00
 Total                          32316077                       87.28                          91.87

Ops by types:
 TYPE                           SIZE                           SPARSITY                       QUANTIZED
 QLinearConv                    9580440                        94.90                          100.00
 Gemm                           65568000                       0.00                           0.00
 Relu                           416                            0.00                           0.00
 GlobalAveragePool              32                             0.00                           0.00
 Gather                         32                             0.00                           0.00
 Unsqueeze                      32                             0.00                           0.00
 Reshape                        32                             0.00                           0.00
 Add                            512                            0.00                           0.00
 QuantizeLinear                 544                            0.00                           0.00
 Shape                          32                             0.00                           0.00
 Concat                         32                             0.00                           0.00
 MaxPool                        32                             0.00                           0.00
 Softmax                        32                             0.00                           0.00
 DequantizeLinear               1056                           0.00                           0.00
 Total                          32235349                       87.28                          91.97

Node Timings for Benchmark # 1:
 NODE_NAME                      AVG_RUNTIME
 Conv_13_quant                  0.24
 MaxPool_23                     0.06
 Conv_37_quant                  0.01
 Conv_60_quant                  0.02
 Conv_83_quant                  0.02
 Conv_105_quant                 0.04
 Conv_129_quant                 0.01
 Conv_152_quant                 0.02
 Conv_175_quant                 0.04
 Conv_199_quant                 0.01
 Conv_222_quant                 0.02
 Conv_245_quant                 0.04
 Conv_269_quant                 0.02
 Conv_292_quant                 0.04
 Conv_315_quant                 0.02
 Conv_337_quant                 0.05
 Conv_361_quant                 0.01
 Conv_384_quant                 0.03
 Conv_407_quant                 0.04
 Conv_431_quant                 0.01
 Conv_454_quant                 0.03
 Conv_477_quant                 0.04
 Conv_501_quant                 0.01
 Conv_524_quant                 0.03
 Conv_547_quant                 0.04
 Conv_571_quant                 0.02
 Conv_594_quant                 0.06
 Conv_617_quant                 0.02
 Conv_639_quant                 0.04
 Conv_663_quant                 0.02
 Conv_686_quant                 0.03
 Conv_709_quant                 0.02
 Conv_733_quant                 0.02
 Conv_756_quant                 0.03
 Conv_779_quant                 0.03
 Conv_803_quant                 0.02
 Conv_826_quant                 0.03
 Conv_849_quant                 0.02
 Conv_873_quant                 0.02
 Conv_896_quant                 0.03
 Conv_919_quant                 0.02
 Conv_943_quant                 0.02
 Conv_966_quant                 0.03
 Conv_989_quant                 0.02
 Conv_1013_quant                0.02
 Conv_1036_quant                0.08
 Conv_1059_quant                0.02
 Conv_1081_quant                0.04
 Conv_1105_quant                0.02
 Conv_1128_quant                0.03
 Conv_1151_quant                0.02
 Conv_1175_quant                0.02
 Conv_1198_quant                0.03
 Conv_1221_quant                0.02
 Add_1230                       0.02
 GlobalAveragePool_1232         0.01
 Gemm_1239                      0.13
 Softmax_1240                   0.00

Params:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE
 zoo:cv/classification/resnet_v 87.28                          91.87                          25530472                       32316077
 1-50/pytorch/sparseml/imagenet
 /pruned95_uniform_quant-none

Ops:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE
 zoo:cv/classification/resnet_v 87.28                          91.97                          25530559                       32235349
 1-50/pytorch/sparseml/imagenet
 /pruned95_uniform_quant-none

Overall:
 MODEL                          LATENCY                        THROUGHPUT                     SUPPORTED_GRAPH                SPARSITY                       QUANTIZED
 zoo:cv/classification/resnet_v 2.07                           482.99                         1.00                           87.28                          91.92
 1-50/pytorch/sparseml/imagenet
 /pruned95_uniform_quant-none

Comparison Analysis!!!
INFO:root:Running analysis `by_layers`
INFO:root:Running analysis `by_types`
Comparing zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_uniform_quant-none with zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_quant-none
Note: comparison analysis displays differences b/w models
Analysis by Layers:
 NAME                           TOTAL                          SIZE                           SPARSITY                       QUANTIZED
 Conv_13_quant                  0.00                           17797                          -23.02                         0.00
 Conv_37_quant                  0.00                           -12395                         35.60                          0.00
 Conv_105_quant                 0.00                           -27783                         19.95                          0.00
 Conv_60_quant                  0.00                           -35754                         12.04                          0.00
 Conv_83_quant                  0.00                           -24483                         17.58                          0.00
 Conv_129_quant                 0.00                           -24321                         18.27                          0.00
 Conv_152_quant                 0.00                           -44395                         14.95                          0.00
 Conv_175_quant                 0.00                           -22073                         15.85                          0.00
 Conv_199_quant                 0.00                           -28740                         21.59                          0.00
 Conv_222_quant                 0.00                           -62094                         20.91                          0.00
 Conv_245_quant                 0.00                           -24567                         17.64                          0.00
 Conv_269_quant                 0.00                           -68264                         25.64                          0.00
 Conv_337_quant                 0.00                           -36103                         3.39                           0.00
 Conv_292_quant                 0.00                           -100855                        8.52                           0.00
 Conv_315_quant                 0.00                           -59474                         11.00                          0.00
 Conv_361_quant                 0.00                           -6340                          1.20                           0.00
 Conv_384_quant                 0.00                           -15507                         1.31                           0.00
 Conv_407_quant                 0.00                           -16490                         3.05                           0.00
 Conv_431_quant                 0.00                           -42059                         7.96                           0.00
 Conv_454_quant                 0.00                           -60726                         5.13                           0.00
 Conv_477_quant                 0.00                           -53472                         9.89                           0.00
 Conv_501_quant                 0.00                           -51095                         9.67                           0.00
 Conv_524_quant                 0.00                           -96002                         8.11                           0.00
 Conv_547_quant                 0.00                           -42929                         7.94                           0.00
 Conv_571_quant                 0.00                           -201843                        19.10                          0.00
 Conv_639_quant                 0.00                           16063                          -0.38                          0.00
 Conv_594_quant                 0.00                           -29779                         0.63                           0.00
 Conv_617_quant                 0.00                           -184451                        8.66                           0.00
 Conv_663_quant                 0.00                           42949                          -2.04                          0.00
 Conv_686_quant                 0.00                           106826                         -2.26                          0.00
 Conv_709_quant                 0.00                           -26411                         1.24                           0.00
 Conv_733_quant                 0.00                           12843                          -0.61                          0.00
 Conv_756_quant                 0.00                           85555                          -1.81                          0.00
 Conv_779_quant                 0.00                           -54739                         2.57                           0.00
 Conv_803_quant                 0.00                           -17264                         0.82                           0.00
 Conv_826_quant                 0.00                           65702                          -1.39                          0.00
 Conv_849_quant                 0.00                           -37274                         1.75                           0.00
 Conv_873_quant                 0.00                           -24843                         1.18                           0.00
 Conv_896_quant                 0.00                           108716                         -2.30                          0.00
 Conv_919_quant                 0.00                           -3621                          0.17                           0.00
 Conv_943_quant                 0.00                           -51370                         2.44                           0.00
 Conv_966_quant                 0.00                           93118                          -1.97                          0.00
 Conv_989_quant                 0.00                           -20021                         0.94                           0.00
 Conv_1013_quant                0.00                           -585285                        13.90                          0.00
 Conv_1081_quant                0.00                           517073                         -3.07                          0.00
 Conv_1036_quant                0.00                           817970                         -4.33                          0.00
 Conv_1059_quant                0.00                           -135267                        1.60                           0.00
 Conv_1105_quant                0.00                           246266                         -2.93                          0.00
 Conv_1128_quant                0.00                           680067                         -3.60                          0.00
 Conv_1151_quant                0.00                           149639                         -1.77                          0.00
 Conv_1175_quant                0.00                           -237861                        2.83                           0.00
 Conv_1198_quant                0.00                           853862                         -4.52                          0.00
 Conv_1221_quant                0.00                           -45653                         0.54                           0.00
 Gemm_1239                      0.00                           57319546                       -87.42                         0.00

Parameters by types:
 TYPE                           SIZE                           SPARSITY                       QUANTIZED
 Weight                         19291958                       -7.62                          0.00
 Bias                           0                              0.00                           0.00
 Total                          19359159                       -7.62                          0.00

Ops by types:
 TYPE                           SIZE                           SPARSITY                       QUANTIZED
 QLinearConv                    1221036                        -0.65                          0.00
 Gemm                           57319546                       -87.42                         0.00
 Relu                           0                              0.00                           0.00
 GlobalAveragePool              0                              0.00                           0.00
 Gather                         0                              0.00                           0.00
 Unsqueeze                      0                              0.00                           0.00
 Reshape                        0                              0.00                           0.00
 Add                            0                              0.00                           0.00
 QuantizeLinear                 0                              0.00                           0.00
 Shape                          0                              0.00                           0.00
 Concat                         0                              0.00                           0.00
 MaxPool                        0                              0.00                           0.00
 Softmax                        0                              0.00                           0.00
 DequantizeLinear               0                              0.00                           0.00
 Total                          19310799                       -7.62                          0.00

Node Timings for Benchmark # 1:
 NODE_NAME                      AVG_RUNTIME
 Conv_13_quant                  -0.00
 MaxPool_23                     0.00
 Conv_37_quant                  -0.01
 Conv_60_quant                  -0.03
 Conv_83_quant                  -0.02
 Conv_105_quant                 -0.02
 Conv_129_quant                 -0.02
 Conv_152_quant                 -0.04
 Conv_175_quant                 -0.01
 Conv_199_quant                 -0.02
 Conv_222_quant                 -0.05
 Conv_245_quant                 -0.01
 Conv_269_quant                 -0.04
 Conv_292_quant                 -0.03
 Conv_315_quant                 -0.01
 Conv_337_quant                 -0.00
 Conv_361_quant                 -0.00
 Conv_384_quant                 -0.01
 Conv_407_quant                 0.01
 Conv_431_quant                 -0.01
 Conv_454_quant                 -0.02
 Conv_477_quant                 0.00
 Conv_501_quant                 -0.01
 Conv_524_quant                 -0.03
 Conv_547_quant                 0.00
 Conv_571_quant                 -0.05
 Conv_594_quant                 -0.00
 Conv_617_quant                 -0.01
 Conv_639_quant                 -0.00
 Conv_663_quant                 0.00
 Conv_686_quant                 0.01
 Conv_709_quant                 -0.01
 Conv_733_quant                 0.00
 Conv_756_quant                 0.01
 Conv_779_quant                 0.00
 Conv_803_quant                 -0.00
 Conv_826_quant                 0.01
 Conv_849_quant                 0.00
 Conv_873_quant                 -0.00
 Conv_896_quant                 0.01
 Conv_919_quant                 0.00
 Conv_943_quant                 -0.00
 Conv_966_quant                 0.01
 Conv_989_quant                 -0.00
 Conv_1013_quant                -0.04
 Conv_1036_quant                0.02
 Conv_1059_quant                -0.00
 Conv_1081_quant                0.01
 Conv_1105_quant                0.01
 Conv_1128_quant                0.02
 Conv_1151_quant                0.00
 Conv_1175_quant                -0.00
 Conv_1198_quant                0.02
 Conv_1221_quant                -0.00
 Add_1230                       0.01
 GlobalAveragePool_1232         -0.00
 Gemm_1239                      0.06
 Softmax_1240                   -0.00

Params:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE
 zoo:cv/classification/resnet_v -7.62                          0.00                           0                              19359159
 1-50/pytorch/sparseml/imagenet
 /pruned95_uniform_quant-none -
 zoo:cv/classification/resnet_v
 1-50/pytorch/sparseml/imagenet
 /pruned95_quant-none

Ops:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE
 zoo:cv/classification/resnet_v -7.62                          0.00                           0                              19310799
 1-50/pytorch/sparseml/imagenet
 /pruned95_uniform_quant-none -
 zoo:cv/classification/resnet_v
 1-50/pytorch/sparseml/imagenet
 /pruned95_quant-none

Overall:
 MODEL                          LATENCY                        THROUGHPUT                     SUPPORTED_GRAPH                SPARSITY                       QUANTIZED
 zoo:cv/classification/resnet_v -0.38                          74.40                          0.00                           -7.62                          0.00
 1-50/pytorch/sparseml/imagenet
 /pruned95_uniform_quant-none -
 zoo:cv/classification/resnet_v
 1-50/pytorch/sparseml/imagenet
 /pruned95_quant-none
```