### PR TITLE
Update: Missed python Version

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Developing SparseZoo
 
-SparseZoo is developed and tested using Python 3.6-3.9.
+SparseZoo is developed and tested using Python 3.7-3.9.
 To develop sparsezoo, you will also need the development dependencies and to follow the styling guidelines.
 
 Here's some details to get started.


### PR DESCRIPTION
This PR updates some missed places, where we were referencing python3.6. All such references have been updated to python3.7