### PR TITLE
download from repo_name, repo_namespace if present

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -342,7 +342,15 @@ class Model(Directory):
             - validation results dict
             - compressed model size in bytes
         """
-        files, model_id, params, validation_results, size = load_files_from_stub(
+        (
+            files,
+            model_id,
+            params,
+            validation_results,
+            size,
+            repo_name,
+            repo_namespace,
+        ) = load_files_from_stub(
             stub=stub,
             valid_params=list(PARAM_DICT.keys()),
         )
@@ -350,7 +358,11 @@ class Model(Directory):
             self._validate_params(params=params)
             self._stub_params.update(params)
 
-        path = os.path.join(SAVE_DIR, model_id)
+        if repo_name and repo_namespace:
+            path = os.path.join(SAVE_DIR, repo_namespace, repo_name)
+        else:
+            path = os.path.join(SAVE_DIR, model_id)
+
         if not files:
             raise ValueError(f"No files found for given stub {stub}")
 

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -144,6 +144,8 @@ def load_files_from_stub(
             "files",
             "benchmark_results",
             "training_results",
+            "repo_name",
+            "repo_namespace",
         ],
     )
 
@@ -177,6 +179,9 @@ def load_files_from_stub(
 
         model_onnx_size_compressed_bytes = model.get("model_onnx_size_compressed_bytes")
 
+        repo_namespace = model.get("repo_namespace")
+        repo_name = model.get("repo_name")
+
         throughput_results = [
             ThroughputResults(**benchmark_result)
             for benchmark_result in benchmark_results
@@ -189,7 +194,15 @@ def load_files_from_stub(
         results["validation"] = validation_results
         results["throughput"] = throughput_results
 
-        return files, model_id, params, results, model_onnx_size_compressed_bytes
+        return (
+            files,
+            model_id,
+            params,
+            results,
+            model_onnx_size_compressed_bytes,
+            repo_name,
+            repo_namespace,
+        )
 
     _LOGGER.warning(f"load_files_from_stub: No models found with the stub:{stub}")
 

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -93,6 +93,8 @@ def test_load_files_from_stub(stub, expected_files):
         params,
         results,
         model_onnx_size_compressed_bytes,
+        repo_name,
+        repo_namespace,
     ) = load_files_from_stub(stub=stub)
     for file_type, file_names_expected in expected_files.items():
         file_names = set(
@@ -103,6 +105,8 @@ def test_load_files_from_stub(stub, expected_files):
     assert params.__eq__({})
     assert results is not None
     assert model_onnx_size_compressed_bytes > 0
+    assert repo_name is not None
+    assert repo_namespace is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
sparsezoo download default is for model-id in ~/.cache.

Make the doanload folder name as repo_name/repo_namaspace if present