### PR TITLE
[Fix] By default, save big ONNX models to `model.onnx` and their external data to `model.data`

### DIFF
--- a/src/sparsezoo/utils/onnx.py
+++ b/src/sparsezoo/utils/onnx.py
@@ -81,7 +81,7 @@ def save_onnx(
     if model.ByteSize() > onnx.checker.MAXIMUM_PROTOBUF:
         _LOGGER.warning(
             "The ONNX model is too large to be saved as a single protobuf."
-            "Saving with external data... "
+            "Saving with external data: 'model.data'"
         )
 
         onnx.save(
@@ -89,6 +89,7 @@ def save_onnx(
             model_path,
             save_as_external_data=True,
             all_tensors_to_one_file=True,
+            location="model.data",
         )
         return True
 


### PR DESCRIPTION
By default, save the external data of the large ONNX models to a file with one unified name: `model.data` (complementary to the analogous name: `model.onnx`)

Tested by:

1. Installing locally the changes from this branch in SparseML
3. Exporting an LLM through transformer export pathway (it already assumes that if the exported model is large, `model.data` is provided. This pathway fails now, but will stop failing once this PR lands.)
4. Model data present:
```bash
(venv) ubuntu@quad-mle-1:~/damian/sparseml/deployment$ ls
config.json  model.data  model.onnx  tokenizer_config.json
```
5. Model data is a valid external data file for the `model.onnx`:
```bash
In [1]: import onnx

In [2]: model_onnx = onnx.load("model.onnx")

In [3]: onnx.check.check_model(model_onnx)
```