### PR TITLE
Make 'validate_onnx' function robust against the models loaded without external data

### DIFF
--- a/src/sparsezoo/utils/onnx.py
+++ b/src/sparsezoo/utils/onnx.py
@@ -27,6 +27,7 @@ from sparsezoo.utils.helpers import clean_path
 _LOGGER = logging.getLogger(__name__)
 
 __all__ = [
+    "onnx_includes_external_data",
     "save_onnx",
     "validate_onnx",
     "load_model",
@@ -48,6 +49,30 @@ __all__ = [
     "extract_node_id",
     "get_node_attributes",
 ]
+
+
+def onnx_includes_external_data(model: ModelProto) -> bool:
+    """
+    Check whether the ModelProto in memory includes the external
+    data or not.
+
+    If the model.onnx does not contain the external data, then the
+    initializers of the model are pointing to the external data file
+    (they are not empty)
+
+    :param model: the ModelProto to check
+    :return True if the model was loaded with external data, False otherwise.
+    """
+
+    initializers = model.graph.initializer
+
+    data_saved_to_disk = any(
+        [initializer.external_data for initializer in initializers]
+    )
+
+    data_included_in_model = not data_saved_to_disk
+
+    return data_included_in_model
 
 
 def save_onnx(
@@ -120,6 +145,14 @@ def validate_onnx(model: Union[str, ModelProto]):
             return
         onnx.checker.check_model(onnx_model)
     except Exception as err:
+        if not onnx_includes_external_data(model):
+            _LOGGER.warning(
+                "Attempting to validate an in-memory ONNX model "
+                "that has been loaded without external data. "
+                "This is currently not supported by the ONNX checker. "
+                "The validation will be skipped."
+            )
+            return
         raise ValueError(f"Invalid onnx model: {err}")
 
 

--- a/src/sparsezoo/utils/onnx.py
+++ b/src/sparsezoo/utils/onnx.py
@@ -66,13 +66,12 @@ def onnx_includes_external_data(model: ModelProto) -> bool:
 
     initializers = model.graph.initializer
 
-    data_saved_to_disk = any(
-        [initializer.external_data for initializer in initializers]
+    is_data_saved_to_disk = any(
+        initializer.external_data for initializer in initializers
     )
+    is_data_included_in_model = not is_data_saved_to_disk
 
-    data_included_in_model = not data_saved_to_disk
-
-    return data_included_in_model
+    return is_data_included_in_model
 
 
 def save_onnx(


### PR DESCRIPTION
Accounting for the scenario, where the in-memory model passed to the `validate_onnx` is loaded without the external data.
Right now, the validator simply fails. What it should do, it should skip the validation and emit a verbose warning - this is what has been implemented.

Testing:
```python
import onnx
from sparsezoo.utils.onnx import validate_onnx
model = onnx.load("/network/damian/sparsegpt_webinar_fp32/sparsegpt_1.3b/model.onnx", load_external_data=False)
validate_onnx(model)
model_ = onnx.load("/network/damian/sparsegpt_webinar_fp32/sparsegpt_1.3b/model.onnx", load_external_data=True)
validate_onnx(model_)
```

```bash
Attempting to validate an in-memory ONNX model that has been loaded without external data. This is currently not supported by the ONNX checker. The validation will be skipped.
Attempting to validate an in-memory ONNX model with size > 2000000000 bytes.`validate_onnx` skipped, as large ONNX models cannot be validated in-memory. To validate this model, save it to disk and call `validate_onnx` on the file path.
```