### PR TITLE
Suppress analytics errors and messages

### DIFF
--- a/src/sparsezoo/analytics.py
+++ b/src/sparsezoo/analytics.py
@@ -129,7 +129,7 @@ class GoogleAnalytics:
             event_params = {}
 
         def _send_request():
-            with suppress_stdout_stderr(suppress=not raise_errors):
+            with suppress_stdout_stderr(suppress=not _DEBUG):
                 event_params.update(self._package_params)
                 event_params["package"] = self._package
                 event_params["version"] = self._version

--- a/src/sparsezoo/analytics.py
+++ b/src/sparsezoo/analytics.py
@@ -24,6 +24,7 @@ import machineid
 import requests
 
 from sparsezoo.utils.gdpr import is_gdpr_country
+from sparsezoo.utils.suppress import suppress_stdout_stderr
 from sparsezoo.version import version as sparsezoo_version
 
 
@@ -128,30 +129,31 @@ class GoogleAnalytics:
             event_params = {}
 
         def _send_request():
-            event_params.update(self._package_params)
-            event_params["package"] = self._package
-            event_params["version"] = self._version
-            payload = {
-                "client_id": self._client_id,
-                "events": [{"name": event_name, "params": event_params}],
-            }
-            headers = {
-                "Content-Type": "application/json",
-            }
-            data = json.dumps(payload)
+            with suppress_stdout_stderr(suppress=not raise_errors):
+                event_params.update(self._package_params)
+                event_params["package"] = self._package
+                event_params["version"] = self._version
+                payload = {
+                    "client_id": self._client_id,
+                    "events": [{"name": event_name, "params": event_params}],
+                }
+                headers = {
+                    "Content-Type": "application/json",
+                }
+                data = json.dumps(payload)
 
-            try:
-                response = requests.post(self._url, headers=headers, data=data)
-                response.raise_for_status()
-                body = response.content
-                if _DEBUG:
-                    print(body)
-            except Exception as err:
-                if _DEBUG:
-                    print(err)
+                try:
+                    response = requests.post(self._url, headers=headers, data=data)
+                    response.raise_for_status()
+                    body = response.content
+                    if _DEBUG:
+                        print(body)
+                except Exception as err:
+                    if _DEBUG:
+                        print(err)
 
-                if raise_errors:
-                    raise err
+                    if raise_errors:
+                        raise err
 
         thread = threading.Thread(target=_send_request)
         thread.start()

--- a/src/sparsezoo/utils/gdpr.py
+++ b/src/sparsezoo/utils/gdpr.py
@@ -17,6 +17,8 @@ from typing import Optional
 import geocoder
 import requests
 
+from sparsezoo.utils.suppress import suppress_stdout_stderr
+
 
 __all__ = ["get_external_ip", "get_country_code", "is_gdpr_country"]
 
@@ -56,26 +58,28 @@ def get_external_ip() -> Optional[str]:
     """
     :return: the external ip of the machine, None if unable to get
     """
-    try:
-        response = requests.get("https://ident.me")
-        external_ip = response.text.strip()
+    with suppress_stdout_stderr():
+        try:
+            response = requests.get("https://ident.me")
+            external_ip = response.text.strip()
 
-        return external_ip
-    except Exception:
-        return None
+            return external_ip
+        except Exception:
+            return None
 
 
 def get_country_code() -> Optional[str]:
     """
     :return: the country code of the machine, None if unable to get
     """
-    try:
-        ip = get_external_ip()
-        geo = geocoder.ip(ip)
+    with suppress_stdout_stderr():
+        try:
+            ip = get_external_ip()
+            geo = geocoder.ip(ip)
 
-        return geo.country
-    except Exception:
-        return None
+            return geo.country
+        except Exception:
+            return None
 
 
 def is_gdpr_country() -> bool:

--- a/src/sparsezoo/utils/suppress.py
+++ b/src/sparsezoo/utils/suppress.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from contextlib import contextmanager
+
+
+__all__ = ["suppress_stdout_stderr", "NullDevice"]
+
+
+class NullDevice:
+    def write(self, s):
+        pass
+
+
+@contextmanager
+def suppress_stdout_stderr(suppress: bool = True):
+    """
+    Suppresses stdout and stderr for the duration of the context.
+    """
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    null_device = NullDevice()
+
+    try:
+        if suppress:
+            # Redirect stdout and stderr to the null device
+            sys.stdout = null_device
+            sys.stderr = null_device
+        yield
+    finally:
+        # Restore the original stdout and stderr
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr


### PR DESCRIPTION
This PR will suppress the following error message from google analytics
```bash
ERROR - 429 Client Error: Too Many Requests for url: http://ipinfo.io/96.89.198.177/json
```

Equivalent of #291 