### PR TITLE
[analytics] Made suppression fixes

### DIFF
--- a/src/sparsezoo/analytics.py
+++ b/src/sparsezoo/analytics.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import json
 import os
 import threading
@@ -25,13 +24,13 @@ import requests
 from requests import HTTPError
 
 from sparsezoo.utils.gdpr import is_gdpr_country
+from sparsezoo.utils.helpers import disable_request_logs
 from sparsezoo.version import version as sparsezoo_version
 
 
 __all__ = ["GoogleAnalytics", "analytics_disabled", "sparsezoo_analytics"]
 
 
-_LOOP = asyncio.get_event_loop()
 _DEBUG = os.getenv("NM_DEBUG_ANALYTICS")
 
 
@@ -140,19 +139,19 @@ class GoogleAnalytics:
                 "Content-Type": "application/json",
             }
             data = json.dumps(payload)
+            with disable_request_logs():
+                try:
+                    response = requests.post(self._url, headers=headers, data=data)
+                    response.raise_for_status()
+                    body = response.content
+                    if _DEBUG:
+                        print(body)
+                except HTTPError as http_error:
+                    if _DEBUG:
+                        print(http_error)
 
-            try:
-                response = requests.post(self._url, headers=headers, data=data)
-                response.raise_for_status()
-                body = response.content
-                if _DEBUG:
-                    print(body)
-            except HTTPError as http_error:
-                if _DEBUG:
-                    print(http_error)
-
-                if raise_errors:
-                    raise http_error
+                    if raise_errors:
+                        raise http_error
 
         thread = threading.Thread(target=_send_request)
         thread.start()

--- a/src/sparsezoo/utils/gdpr.py
+++ b/src/sparsezoo/utils/gdpr.py
@@ -19,6 +19,8 @@ import geocoder
 import requests
 from requests import HTTPError
 
+from sparsezoo.utils.helpers import disable_request_logs
+
 
 __all__ = ["get_external_ip", "get_country_code", "is_gdpr_country"]
 
@@ -59,7 +61,8 @@ def get_external_ip() -> Optional[str]:
     :return: the external ip of the machine, None if unable to get
     """
     try:
-        response = requests.get("https://ident.me")
+        with disable_request_logs():
+            response = requests.get("https://ident.me")
         external_ip = response.text.strip()
 
         return external_ip

--- a/src/sparsezoo/utils/gdpr.py
+++ b/src/sparsezoo/utils/gdpr.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 from typing import Optional
 
 import geocoder
@@ -84,6 +85,8 @@ def is_gdpr_country() -> bool:
     :return: True if the country code of the machine is in the GDPR list,
              False otherwise
     """
-    country_code = get_country_code()
+    with contextlib.redirect_stderr(None):
+        # suppress geocoder error logging
+        country_code = get_country_code()
 
     return country_code is None or country_code in _GDPR_COUNTRY_CODES

--- a/src/sparsezoo/utils/helpers.py
+++ b/src/sparsezoo/utils/helpers.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import glob
+import logging
 import os
+from contextlib import contextmanager
 from typing import Any
 
 
@@ -23,6 +25,7 @@ __all__ = [
     "clean_path",
     "remove_tar_duplicates",
     "convert_to_bool",
+    "disable_request_logs",
 ]
 
 
@@ -87,3 +90,20 @@ def clean_path(path: str) -> str:
     :return: a cleaned version that expands the user path and creates an absolute path
     """
     return os.path.abspath(os.path.expanduser(path))
+
+
+@contextmanager
+def disable_request_logs():
+    """
+    Context manager for disabling logs for a requests session
+    """
+    loggers = [logging.getLogger("requests"), logging.getLogger("urllib3")]
+
+    original_disabled_states = [logger.disabled for logger in loggers]
+    for logger in loggers:
+        logger.disabled = True
+
+    yield
+
+    for logger, original_disabled_state in zip(loggers, original_disabled_states):
+        logger.disabled = original_disabled_state


### PR DESCRIPTION
This PR makes the requested suppression fixes, the work is two fold:

- Disable all logs from `request` and `urllib3` loggers: Added a context manager for that
- Disable all stderr from `is_gdpr_country`: Accomplished using `contextlib.redirect_stderr()`

After this change me and @KSGulin verified locally that output was still produced by utilities such as `deepsparse.check_hardware`:

```bash
deepsparse.check_hardware 
/home/rahul/.venvs/sparsezoo/lib/python3.10/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.16) or chardet (5.1.0)/charset_normalizer (2.0.12) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
GenuineIntel CPU detected with 10 cores. (1 sockets with 10 cores each)
DeepSparse FP32 model performance supported: True.
DeepSparse INT8 (quantized) model performance supported: TRUE (emulated).

Non VNNI system detected. Performance speedups for INT8 (quantized) models is available, but will be slower compared with a VNNI system. Set NM_FAST_VNNI_EMULATION=True in the environment to enable faster emulated inference which may have a minor effect on accuracy.

Additional CPU info: {'L1_data_cache_size': 32768, 'L1_instruction_cache_size': 32768, 'L2_cache_size': 1048576, 'L3_cache_size': 14417920, 'architecture': 'x86_64', 'available_cores_per_socket': 10, 'available_num_cores': 10, 'available_num_hw_threads': 20, 'available_num_numa': 1, 'available_num_sockets': 1, 'available_sockets': 1, 'available_threads_per_core': 2, 'bf16': False, 'cores_per_socket': 10, 'dotprod': False, 'i8mm': False, 'isa': 'avx512', 'num_cores': 10, 'num_hw_threads': 20, 'num_numa': 1, 'num_sockets': 1, 'threads_per_core': 2, 'vbmi': False, 'vbmi2': False, 'vendor': 'GenuineIntel', 'vendor_id': 'Intel', 'vendor_model': 'Intel(R) Core(TM) i9-7900X CPU @ 3.30GHz', 'vnni': False, 'zen1': False}
```

And also that integration tests for deepsparse are green ✅ 
```bash
(sparsezoo) 🥃 deepsparse (main) 💍 make test_integrations 
Running package integrations tests
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.10.11, pytest-7.3.1, pluggy-1.0.0
rootdir: /home/rahul/github_projects/deepsparse
configfile: pyproject.toml
plugins: flaky-3.7.0, anyio-3.7.0
collected 2 items                                                                                                                                                         

integrations/haystack/tests/test_smoke.py ..                                                                                                                        [100%]
```

Noting: It will take time for `local-install-checks` [here](https://github.com/neuralmagic/deepsparse/blob/3eaa563939482263a4a8a0fccb155deac51db86f/.github/workflows/local-install-check.yaml#L24) in `deepsparse` to be green as they install `sparsezoo nightly` directly from pypi


Also ran the following to verify:
```python
from multiprocessing import Pool
import subprocess


def task(*args, **kwargs):
    return subprocess.check_output(["deepsparse.check_hardware"])

with Pool(100) as p:
    p.map(task, list(range(1000)))

out = task()
print(out)
```

Output:
```bash
b"GenuineIntel CPU detected with 10 cores. (1 sockets with 10 cores each)\nDeepSparse FP32 model performance supported: True.\nDeepSparse INT8 (quantized) model performance supported: TRUE (emulated).\n\nNon VNNI system detected. Performance speedups for INT8 (quantized) models is available, but will be slower compared with a VNNI system. Set NM_FAST_VNNI_EMULATION=True in the environment to enable faster emulated inference which may have a minor effect on accuracy.\n\nAdditional CPU info: {'L1_data_cache_size': 32768, 'L1_instruction_cache_size': 32768, 'L2_cache_size': 1048576, 'L3_cache_size': 14417920, 'architecture': 'x86_64', 'available_cores_per_socket': 10, 'available_num_cores': 10, 'available_num_hw_threads': 20, 'available_num_numa': 1, 'available_num_sockets': 1, 'available_sockets': 1, 'available_threads_per_core': 2, 'bf16': False, 'cores_per_socket': 10, 'dotprod': False, 'i8mm': False, 'isa': 'avx512', 'num_cores': 10, 'num_hw_threads': 20, 'num_numa': 1, 'num_sockets': 1, 'threads_per_core': 2, 'vbmi': False, 'vbmi2': False, 'vendor': 'GenuineIntel', 'vendor_id': 'Intel', 'vendor_model': 'Intel(R) Core(TM) i9-7900X CPU @ 3.30GHz', 'vnni': False, 'zen1': False}\n"
```