### PR TITLE
Cleanup loggers to prevent double-logging

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -43,6 +43,8 @@ from sparsezoo.validation import IntegrationValidator
 
 __all__ = ["Model"]
 
+_LOGGER = logging.getLogger(__name__)
+
 ALLOWED_CHECKPOINT_VALUES = {"prepruning", "postpruning", "preqat", "postqat"}
 ALLOWED_DEPLOYMENT_VALUES = {"default"}
 
@@ -280,7 +282,7 @@ class Model(Directory):
                         )
 
                     else:
-                        logging.debug(
+                        _LOGGER.debug(
                             f"Attempted to download file {key}, "
                             f"but it is `None`. The file is being skipped..."
                         )
@@ -307,7 +309,7 @@ class Model(Directory):
 
         if validate_onnxruntime:
             if not self.inference_runner.validate_with_onnx_runtime():
-                logging.warning(
+                _LOGGER.warning(
                     "Failed to validate the compatibility of "
                     "`sample_inputs` files with the `model.onnx` model."
                 )
@@ -465,7 +467,7 @@ class Model(Directory):
                 )
 
         if not match:
-            logging.debug(
+            _LOGGER.debug(
                 "Could not find a directory with "
                 f"display_name / regex_pattern: {display_name}"
             )
@@ -529,7 +531,7 @@ class Model(Directory):
                         match = False
 
         if not match:
-            logging.debug(
+            _LOGGER.debug(
                 "Could not find a file with "
                 f"display_name / regex_pattern: {display_name}"
             )
@@ -641,7 +643,7 @@ class Model(Directory):
                 file.download(destination_path=directory_path)
                 return True
             else:
-                logging.warning(
+                _LOGGER.warning(
                     f"Failed to download file {file.name}. The url of the file is None."
                 )
                 return False

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -155,7 +155,7 @@ def load_files_from_stub(
             f"No matching models found with stub: {stub}." "Please try another stub"
         )
     if matching_models > 1:
-        logging.warning(
+        _LOGGER.warning(
             f"{len(models)} found from the stub: {stub}"
             "Using the first model to obtain metadata."
             "Proceed with caution"
@@ -507,7 +507,7 @@ def setup_model(
     # iterate over the arguments (files)
     for name, file in files_dict.items():
         if file is None:
-            logging.debug(f"File {name} not provided. It will be omitted.")
+            _LOGGER.debug(f"File {name} not provided. It will be omitted.")
         else:
             if isinstance(file, str):
                 # if file is a string, convert it to

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -31,6 +31,8 @@ from sparsezoo.utils import DataLoader, Dataset, load_numpy_list
 
 __all__ = ["NumpyDirectory", "SelectDirectory"]
 
+_LOGGER = logging.getLogger(__name__)
+
 NUMPY_DIRECTORY_NAMES = ["sample_inputs", "sample_outputs"]
 
 
@@ -86,7 +88,7 @@ class NumpyDirectory(Directory):
 
         if model:
             if not self._validate_model(model):
-                logging.warning(
+                _LOGGER.warning(
                     "Could not validate an NumpyDirectory given the provided onnx model."  # noqa: E501
                 )
                 return False

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -27,6 +27,8 @@ from .file import File
 
 __all__ = ["Directory", "is_directory"]
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class Directory(File):
     """
@@ -131,7 +133,7 @@ class Directory(File):
         if is_valid:
             return True
         else:
-            logging.warning(
+            _LOGGER.warning(
                 "Following files: "
                 f"{[key for key, value in validations.items() if not value]} "
                 "were not successfully validated."
@@ -178,11 +180,11 @@ class Directory(File):
                     return
 
                 except Exception as err:
-                    logging.error(err)
-                    logging.error(traceback.format_exc())
+                    _LOGGER.error(err)
+                    _LOGGER.error(traceback.format_exc())
                     time.sleep(retry_sleep_sec)
-                logging.error(f"Trying attempt {attempt + 1} of {retries}.")
-            logging.error("Download retry failed...")
+                _LOGGER.error(f"Trying attempt {attempt + 1} of {retries}.")
+            _LOGGER.error("Download retry failed...")
             raise Exception("Exceed max retry attempts: {} failed".format(retries))
 
         # Directory can represent a folder or directory.

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -29,6 +29,8 @@ from sparsezoo.utils import download_file, load_numpy_list
 
 __all__ = ["File"]
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class File:
     """
@@ -149,7 +151,7 @@ class File:
             )
 
         if self._path is not None:
-            logging.warning(
+            _LOGGER.warning(
                 f"Overwriting the current location of the File: {self._path} "
                 f"with the new location: {new_file_path}."
             )
@@ -165,11 +167,11 @@ class File:
                 return
 
             except Exception as err:
-                logging.error(err)
-                logging.error(traceback.format_exc())
+                _LOGGER.error(err)
+                _LOGGER.error(traceback.format_exc())
                 time.sleep(retry_sleep_sec)
-            logging.error(f"Trying attempt {attempt + 1} of {retries}.")
-        logging.error("Download retry failed...")
+            _LOGGER.error(f"Trying attempt {attempt + 1} of {retries}.")
+        _LOGGER.error("Download retry failed...")
         raise Exception("Exceed max retry attempts: {} failed".format(retries))
 
     def validate(self, strict_mode: bool = True) -> bool:
@@ -183,7 +185,7 @@ class File:
         :return: boolean flag; True if File instance is loadable, otherwise False
         """
         if not self.name or (not self._path and not self.url):
-            logging.warning(
+            _LOGGER.warning(
                 "Failed to validate a file. A valid file needs to "
                 "have a valid `name` AND a valid `path` or `url`."
             )
@@ -254,7 +256,7 @@ class File:
             return yaml_dict
 
         except Exception as error:  # noqa: F841
-            logging.debug(error)
+            _LOGGER.debug(error)
 
     def _validate_markdown(self, strict_mode):
         # test if .md file is a model_card
@@ -316,4 +318,4 @@ class File:
         if strict_mode:
             raise ValueError(error_msg)
         else:
-            logging.warning(error_msg)
+            _LOGGER.warning(error_msg)

--- a/src/sparsezoo/search/search.py
+++ b/src/sparsezoo/search/search.py
@@ -21,6 +21,8 @@ from sparsezoo.api.graphql import GraphQLAPI
 
 __all__ = ["search_models", "model_args_to_stub"]
 
+_LOGGER = logging.getLogger(__name__)
+
 
 def search_models(
     domain: str,
@@ -101,7 +103,7 @@ def search_models(
 
     arguments = {key: value for key, value in args.items() if value is not None}
 
-    logging.debug(f"Search_models: searching models with args {args}")
+    _LOGGER.debug(f"Search_models: searching models with args {args}")
 
     response_json = GraphQLAPI().fetch(
         operation_body="models",


### PR DESCRIPTION
This has bugged me for so long :) 

I tested with deepsparse.benchmark using a SparseZoo stub

Before:
```
deepsparse.benchmark zoo:cv/detection/yolov5-n/pytorch/ultralytics/coco/base_quant-none
2023-06-06 14:46:45 deepsparse   INFO     Thread pinning to cores enabled
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0 COMMUNITY | (3cd0b1a4) (optimized) (system=avx512, binary=avx512)
2023-06-06 14:46:47 deepsparse   INFO     deepsparse.engine.Engine:
        onnx_file_path: /home/mgoin/.cache/sparsezoo/42de2f1d-3a2c-4445-aa94-63aa12e1e2a5/model.onnx
        batch_size: 1
        num_cores: 18
        num_streams: 1
        scheduler: Scheduler.default
        fraction_of_supported_ops: 1.0
        cpu_avx_type: avx512
        cpu_vnni: False
INFO:deepsparse:deepsparse.engine.Engine:
        onnx_file_path: /home/mgoin/.cache/sparsezoo/42de2f1d-3a2c-4445-aa94-63aa12e1e2a5/model.onnx
        batch_size: 1
        num_cores: 18
        num_streams: 1
        scheduler: Scheduler.default
        fraction_of_supported_ops: 1.0
        cpu_avx_type: avx512
        cpu_vnni: False
2023-06-06 14:46:47 deepsparse.utils.onnx INFO     Generating input 'images', type = float32, shape = [1, 3, 640, 640]
INFO:deepsparse.utils.onnx:Generating input 'images', type = float32, shape = [1, 3, 640, 640]
2023-06-06 14:46:47 deepsparse   INFO     Starting 'singlestream' performance measurements for 10 seconds
```

After
```
deepsparse.benchmark zoo:cv/detection/yolov5-n/pytorch/ultralytics/coco/base_quant-none
2023-06-06 14:56:47 deepsparse.benchmark.benchmark_model INFO     Thread pinning to cores enabled
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0 COMMUNITY | (3cd0b1a4) (optimized) (system=avx512, binary=avx512)
2023-06-06 14:56:49 deepsparse.benchmark.benchmark_model INFO     deepsparse.engine.Engine:
        onnx_file_path: /home/mgoin/.cache/sparsezoo/neuralmagic/yolov5-n-coco-base_quantized/model.onnx
        batch_size: 1
        num_cores: 18
        num_streams: 1
        scheduler: Scheduler.default
        fraction_of_supported_ops: 1.0
        cpu_avx_type: avx512
        cpu_vnni: False
2023-06-06 14:56:49 deepsparse.utils.onnx INFO     Generating input 'images', type = uint8, shape = [1, 3, 640, 640]
2023-06-06 14:56:49 deepsparse.benchmark.benchmark_model INFO     Starting 'singlestream' performance measurements for 10 seconds
```