### PR TITLE
Update numpy 1.21.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ print(f"loaded version {version} from src/sparsezoo/version.py")
 _PACKAGE_NAME = "sparsezoo" if is_release else "sparsezoo-nightly"
 
 _deps = [
-    "numpy>=1.0.0,<=1.21.6",
+    "numpy>=1.0.0",
     "onnx>=1.5.0,<1.15.0",
     "pyyaml>=5.1.0",
     "requests>=2.0.0",


### PR DESCRIPTION
Updates support to latest numpy
Needed to support deepsparse numpy version upgrade from neuralmagic/deepsparse#1094

The deepsparse change was made to support a ragged sequence being created in question answering pipeline during `spans_extra_info` computation; landing this diff along with   https://github.com/neuralmagic/sparseml/pull/1623 also fixes a few google colab errors we were seeing before.