### PR TITLE
[Bug-fix] Set explicit ORT providers

### DIFF
--- a/src/sparsezoo/inference/inference_runner.py
+++ b/src/sparsezoo/inference/inference_runner.py
@@ -133,7 +133,9 @@ class InferenceRunner:
                 f"onnxruntime install not detected for sample inference: {err}"
             )
 
-        ort_sess = onnxruntime.InferenceSession(self.onnx_file.path)
+        ort_sess = onnxruntime.InferenceSession(
+            self.onnx_file.path, providers=["CPUExecutionProvider"]
+        )
         model = onnx.load(self.onnx_file.path)
         input_names = [inp.name for inp in model.graph.input]
 

--- a/src/sparsezoo/utils/node_inference.py
+++ b/src/sparsezoo/utils/node_inference.py
@@ -81,7 +81,9 @@ def extract_nodes_shapes_and_dtypes_ort(
 
     sess_options = onnxruntime.SessionOptions()
     sess_options.log_severity_level = 3
-    sess = onnxruntime.InferenceSession(model_copy.SerializeToString(), sess_options)
+    sess = onnxruntime.InferenceSession(
+        model_copy.SerializeToString(), sess_options, providers=["CPUExecutionProvider"]
+    )
 
     input_value_dict = {}
     for input in model_copy.graph.input:


### PR DESCRIPTION
ORT >= 1.9 requires explicitly setting the ORT execution providers and will fail without them. This PR simply updates ORT inference sessions to use `CPUExecutionProvider`

Analyze output prior to this fix:
```
INFO:sparsezoo.analyze_cli:Starting Analysis ...
WARNING:sparsezoo.utils.node_inference:Extracting shapes using ONNX Runtime session failed: This ORT build has ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'] enabled. Since ORT 1.9, you are required to explicitly set the providers parameter when instantiating InferenceSession. For example, onnxruntime.InferenceSession(..., providers=['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'], ...)
WARNING:sparsezoo.utils.node_inference:Falling back to ONNX shape_inference
WARNING:sparsezoo.utils.calculate_ops:Invalid shape, skipping ops calculation for /classifier/fc/Gemm
WARNING:sparsezoo.utils.calculate_ops:Invalid shape, skipping four block ops calculation for /classifier/fc/Gemm
INFO:sparsezoo.analyze_cli:Analysis complete, collating results...
...
```

Analyze output after the fix:
```
INFO:sparsezoo.analyze_cli:Starting Analysis ...
INFO:sparsezoo.analyze_cli:Analysis complete, collating results...
...
```

**Test plan**
Local run of sparsezoo.analyse.

