### PR TITLE
pin pydantic to <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ _deps = [
     "pyyaml>=5.1.0",
     "requests>=2.0.0",
     "tqdm>=4.0.0",
-    "pydantic>=1.8.2",
+    "pydantic>=1.8.2,<2.0.0",
     "click>=7.1.2,!=8.0.0",  # latest version < 8.0 + blocked version with reported bug
     "protobuf>=3.12.2",
     "pandas>1.3",


### PR DESCRIPTION
see https://github.com/neuralmagic/deepsparse/pull/1104

testing and support for latest pydantic to be added in future release