### PR TITLE
Fix the dimension for nodes with 0 dim

### DIFF
--- a/src/sparsezoo/utils/onnx.py
+++ b/src/sparsezoo/utils/onnx.py
@@ -302,6 +302,9 @@ def group_four_block(array: numpy.ndarray, pad_value: bool = True) -> numpy.ndar
     else:
         input_channel_dim = 0
 
+    if array.ndim == 0:
+        array = numpy.array([array], dtype=array.dtype)
+
     transpose_arg = list(range(array.ndim))
     del transpose_arg[input_channel_dim]
     transpose_arg.append(input_channel_dim)

--- a/src/sparsezoo/utils/onnx.py
+++ b/src/sparsezoo/utils/onnx.py
@@ -296,14 +296,14 @@ def group_four_block(array: numpy.ndarray, pad_value: bool = True) -> numpy.ndar
     :param pad_value: value to pad remainder block with
     :return: array grouped into blocks with shape [-1, 4]
     """
+    if array.ndim == 0:
+        array = numpy.array([array], dtype=array.dtype)
+
     # Transpose so input channels are last
     if array.ndim > 2:
         input_channel_dim = 1
     else:
         input_channel_dim = 0
-
-    if array.ndim == 0:
-        array = numpy.array([array], dtype=array.dtype)
 
     transpose_arg = list(range(array.ndim))
     del transpose_arg[input_channel_dim]


### PR DESCRIPTION
For this ticket: https://app.asana.com/0/1204777926187571/1205044048530908/f

Fix the dim for arrays with 0 dim. This is currently causing `sparsezoo.analyze` to fail.