### PR TITLE
Add filepath endings to download logs

### DIFF
--- a/src/sparsezoo/utils/download.py
+++ b/src/sparsezoo/utils/download.py
@@ -205,7 +205,7 @@ def download_file(
         ):
             bar = tqdm_auto(
                 total=progress.content_length,  # the total iteration
-                desc=progress_title if progress_title else "downloading...",
+                desc=progress_title if progress_title else f"Downloading (…){dest_path[-20:]}: ",
                 unit="B",  # unit string to be displayed
                 unit_scale=True,  # let tqdm to determine the scale in kilo, mega, etc.
                 unit_divisor=1024,  # is used when unit_scale is true

--- a/src/sparsezoo/utils/download.py
+++ b/src/sparsezoo/utils/download.py
@@ -205,7 +205,9 @@ def download_file(
         ):
             bar = tqdm_auto(
                 total=progress.content_length,  # the total iteration
-                desc=progress_title if progress_title else f"Downloading (…){dest_path[-20:]}: ",
+                desc=progress_title
+                if progress_title
+                else f"Downloading (…){dest_path[-20:]}: ",
                 unit="B",  # unit string to be displayed
                 unit_scale=True,  # let tqdm to determine the scale in kilo, mega, etc.
                 unit_divisor=1024,  # is used when unit_scale is true


### PR DESCRIPTION
Now you get useful output on what is downloading

```
deepsparse.benchmark zoo:nlp/question_answering/bert-large/pytorch/huggingface/squad/pruned80_quant-none-vnni
Downloading (…)quantized/model.onnx: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 320M/320M [00:05<00:00, 63.7MB/s]

sparsezoo.download zoo:cv/classification/mobilenet_v2-1.0/pytorch/sparseml/imagenet/base-none
INFO:root:Downloading files from model 'zoo:cv/classification/mobilenet_v2-1.0/pytorch/sparseml/imagenet/base-none'
Downloading (…)e/training/model.pth: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13.5M/13.5M [00:00<00:00, 34.3MB/s]
Downloading (…)eployment/model.onnx: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13.5M/13.5M [00:00<00:00, 74.3MB/s]
Downloading (…)ple_originals.tar.gz: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4.07M/4.07M [00:00<00:00, 38.8MB/s]
Downloading (…)sample_inputs.tar.gz: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.31M/3.31M [00:00<00:00, 22.3MB/s]
Downloading (…)ample_outputs.tar.gz: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 151k/151k [00:00<00:00, 6.88MB/s]
Downloading (…)sample_labels.tar.gz: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 170k/170k [00:00<00:00, 7.94MB/s]
Downloading (…)agenet-base/model.md: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 691/691 [00:00<00:00, 246kB/s]
Downloading (…)enet-base/model.onnx: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13.5M/13.5M [00:00<00:00, 61.5MB/s]
Download results
```