### PR TITLE
default Model.onnx_model to target onnx.model.tar.gz

### DIFF
--- a/src/sparsezoo/analyze/utils/models.py
+++ b/src/sparsezoo/analyze/utils/models.py
@@ -255,7 +255,7 @@ class Entry(BaseModel):
             my_value = getattr(self, field)
             other_value = getattr(other, field)
 
-            assert type(my_value) == type(other_value)
+            assert type(my_value) is type(other_value)
             if field == "section_name":
                 new_fields[field] = my_value
             elif isinstance(my_value, str):

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -34,6 +34,7 @@ from sparsezoo.objects import (
     Directory,
     File,
     NumpyDirectory,
+    OnnxGz,
     SelectDirectory,
     is_directory,
 )
@@ -156,7 +157,14 @@ class Model(Directory):
             stub_params=self.stub_params,
         )
 
-        self.onnx_model: File = self._file_from_files(files, display_name="model.onnx")
+        self._onnx_gz: Directory = self._directory_from_files(
+            files, directory_class=OnnxGz, display_name="model.onnx.tar.gz"
+        )
+        self.onnx_model: File = (
+            self._file_from_files(files, display_name="model.onnx.")
+            if self._onnx_gz is None
+            else self._onnx_gz  # if onnx.model.tar.gz present defer to that file
+        )
 
         self.analysis: File = self._file_from_files(files, display_name="analysis.yaml")
         self.benchmarks: File = self._file_from_files(

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -161,7 +161,7 @@ class Model(Directory):
             files, directory_class=OnnxGz, display_name="model.onnx.tar.gz"
         )
         self.onnx_model: File = (
-            self._file_from_files(files, display_name="model.onnx.")
+            self._file_from_files(files, display_name="model.onnx")
             if self._onnx_gz is None
             else self._onnx_gz  # if onnx.model.tar.gz present defer to that file
         )

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -29,7 +29,7 @@ from sparsezoo.model.result_utils import (
     ThroughputResults,
     ValidationResult,
 )
-from sparsezoo.objects import Directory, File, NumpyDirectory
+from sparsezoo.objects import Directory, File, NumpyDirectory, OnnxGz
 from sparsezoo.utils import BASE_API_URL, convert_to_bool, save_numpy
 
 
@@ -575,6 +575,12 @@ def _copy_file_contents(
             for _file in file:
                 copy_path = os.path.join(output_dir, os.path.basename(_file.path))
                 _copy_and_overwrite(_file.path, copy_path, shutil.copyfile)
+        elif isinstance(file, OnnxGz):
+            # copy all contents of unzipped onnx.tar.gz file to top level of output
+            onnx_gz_path = (
+                os.path.dirname(file.path) if os.path.isfile(file.path) else file.path
+            )
+            shutil.copytree(onnx_gz_path, output_dir, dirs_exist_ok=True)
         elif isinstance(file, Directory):
             copy_path = os.path.join(output_dir, os.path.basename(file.path))
             _copy_and_overwrite(file.path, copy_path, shutil.copytree)

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -280,16 +280,17 @@ class OnnxGz(Directory):
     """
     Special class to handle onnx.model.tar.gz files.
     Desired behavior is that all information about files included in the tarball are
-    available however, when the file.path is accessed, it will point only to the
-    `model.onnx` as this is the expected behavior for loading, additionally,
+    available however, when the file's `path` property is accessed, it will point only
+    to the `model.onnx` as this is the expected behavior for loading an onnx model
+    with or without external data.
     """
 
     @property
     def path(self):
-        super().path  # call self.path to download initial file if not already
+        super().path()  # call self.path to download initial file if not already
         if self.is_archive:
             self.unzip()
         if os.path.isdir(self._path) and "model.onnx" in os.listdir(self._path):
-            # if unzipped into a directory, refer direclty to model.onnx
+            # if unzipped into a directory, refer directly to model.onnx
             self._path = os.path.join(self._path, "model.onnx")
         return self._path

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -280,7 +280,7 @@ class OnnxGz(Directory):
     """
     Special class to handle onnx.model.tar.gz files.
     Desired behavior is that all information about files included in the tarball are
-    available however, when the file's `path` property is accessed, it will point only
+    available however, when the `path` property is accessed, it will point only
     to the `model.onnx` as this is the expected behavior for loading an onnx model
     with or without external data.
     """

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -287,7 +287,7 @@ class OnnxGz(Directory):
 
     @property
     def path(self):
-        super().path()  # call self.path to download initial file if not already
+        _ = super().path  # call self.path to download initial file if not already
         if self.is_archive:
             self.unzip()
         if os.path.isdir(self._path) and "model.onnx" in os.listdir(self._path):

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -18,6 +18,7 @@ Class objects for standardization and validation of a model folder structure
 
 
 import logging
+import os.path
 from collections import OrderedDict
 from typing import Dict, List, Optional, Union
 
@@ -29,7 +30,11 @@ from sparsezoo.objects.file import File
 from sparsezoo.utils import DataLoader, Dataset, load_numpy_list
 
 
-__all__ = ["NumpyDirectory", "SelectDirectory"]
+__all__ = [
+    "NumpyDirectory",
+    "SelectDirectory",
+    "OnnxGz",
+]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -269,3 +274,22 @@ class SelectDirectory(Directory):
     @available.setter
     def available(self, value):
         self._available = value
+
+
+class OnnxGz(Directory):
+    """
+    Special class to handle onnx.model.tar.gz files.
+    Desired behavior is that all information about files included in the tarball are
+    available however, when the file.path is accessed, it will point only to the
+    `model.onnx` as this is the expected behavior for loading, additionally,
+    """
+
+    @property
+    def path(self):
+        super().path  # call self.path to download initial file if not already
+        if self.is_archive:
+            self.unzip()
+        if os.path.isdir(self._path) and "model.onnx" in os.listdir(self._path):
+            # if unzipped into a directory, refer direclty to model.onnx
+            self._path = os.path.join(self._path, "model.onnx")
+        return self._path

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -256,7 +256,7 @@ class Directory(File):
         self._path = tar_file_path
         self.is_archive = True
 
-    def unzip(self, extract_directory: Optional[str] = None, force: bool = False):
+    def unzip(self, extract_directory: Optional[str] = None, force: bool = True):
         """
         Extracts a tar archive Directory.
         The extracted files would be saved in the parent directory of

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -41,6 +41,8 @@ class Directory(File):
     :param path: path of the Directory
     :param url: url of the Directory
     :param parent_directory: path of the parent Directory
+    :param force: boolean flag; True to force unzipping of archive files.
+        Default is False.
     """
 
     def __init__(
@@ -50,6 +52,7 @@ class Directory(File):
         path: Optional[str] = None,
         url: Optional[str] = None,
         parent_directory: Optional[str] = None,
+        force: bool = False,
     ):
 
         self.files = (
@@ -63,7 +66,7 @@ class Directory(File):
         )
 
         if self._unpack():
-            self.unzip()
+            self.unzip(force=force)
 
     @classmethod
     def from_file(cls, file: File) -> "Directory":
@@ -256,7 +259,7 @@ class Directory(File):
         self._path = tar_file_path
         self.is_archive = True
 
-    def unzip(self, extract_directory: Optional[str] = None, force: bool = True):
+    def unzip(self, extract_directory: Optional[str] = None, force: bool = False):
         """
         Extracts a tar archive Directory.
         The extracted files would be saved in the parent directory of
@@ -265,7 +268,7 @@ class Directory(File):
         :param extract_directory: the local path to create
             folder Directory at (default = None)
         :param force: if True, will always unzip, even if the target directory
-            already exists. Default True
+            already exists. Default False
         """
         if self._path is None:
             # use path property to download so path exists

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -207,6 +207,8 @@ class Directory(File):
         :return: File if found, otherwise None
         """
         for file in self.files:
+            if file is None:
+                continue
             if file.name == file_name:
                 return file
             if isinstance(file, Directory):
@@ -254,7 +256,7 @@ class Directory(File):
         self._path = tar_file_path
         self.is_archive = True
 
-    def unzip(self, extract_directory: Optional[str] = None):
+    def unzip(self, extract_directory: Optional[str] = None, force: bool = False):
         """
         Extracts a tar archive Directory.
         The extracted files would be saved in the parent directory of
@@ -262,10 +264,15 @@ class Directory(File):
 
         :param extract_directory: the local path to create
             folder Directory at (default = None)
+        :param force: if True, will always unzip, even if the target directory
+            already exists. Default True
         """
+        if self._path is None:
+            # use path property to download so path exists
+            self._path = self.path
         files = []
         if extract_directory is None:
-            extract_directory = os.path.dirname(self.path)
+            extract_directory = os.path.dirname(self._path)
 
         if not self.is_archive:
             raise ValueError(
@@ -274,14 +281,17 @@ class Directory(File):
             )
 
         name = ".".join(self.name.split(".")[:-2])
-        tar = tarfile.open(self.path, "r")
         path = os.path.join(extract_directory, name)
 
-        for member in tar.getmembers():
-            member.name = os.path.basename(member.name)
-            tar.extract(member=member, path=path)
-            files.append(File(name=member.name, path=os.path.join(path, member.name)))
-        tar.close()
+        if not os.path.exists(path) or force:  # do not re-unzip if not forced
+            tar = tarfile.open(self._path, "r")
+            for member in tar.getmembers():
+                member.name = os.path.basename(member.name)
+                tar.extract(member=member, path=path)
+                files.append(
+                    File(name=member.name, path=os.path.join(path, member.name))
+                )
+            tar.close()
 
         self.name = name
         self.files = files

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -30,6 +30,7 @@ files_ic = {
     "logs",
     "onnx",
     "model.onnx",
+    "model.onnx.tar.gz",
     "recipe",
     "sample_inputs.tar.gz",
     "sample_originals.tar.gz",
@@ -198,6 +199,7 @@ class TestModel:
                 "sample_outputs_deepsparse",
             ]:
                 expected_files.update({file_name, file_name + ".tar.gz"})
+
         assert not set(os.listdir(temp_dir.name)).difference(expected_files)
 
     def test_validate(self, setup):
@@ -223,7 +225,7 @@ class TestModel:
         os.makedirs(onnx_folder_dir)
         for opset in range(1, 3):
             shutil.copyfile(
-                os.path.join(directory_path, "model.onnx"),
+                os.path.join(directory_path, "deployment", "model.onnx"),
                 os.path.join(onnx_folder_dir, f"model.{opset}.onnx"),
             )
 

--- a/tests/sparsezoo/objects/test_directory.py
+++ b/tests/sparsezoo/objects/test_directory.py
@@ -112,7 +112,7 @@ class TestDirectory:
         ) = setup
         directory = Directory(name=name, files=files, path=path)
         directory.gzip()
-        new_directory = Directory(name=directory.name, path=directory.path)
+        new_directory = Directory(name=directory.name, path=directory.path, force=True)
         assert os.path.isdir(new_directory.path)
         assert new_directory.path == directory.path.replace(".tar.gz", "")
         assert new_directory.files


### PR DESCRIPTION
currently, sparsezoo does not have great support for onnx models saved with external data out of the box. especially for user friendly and deepsparse compatible flows such as `Model.onnx_model.path`.

Better support will be added in a future backend update - to fix this now, this PR updates the default target for `Model.onnx_model` to be the `model.onnx.tar.gz` where possible.  A helper class is added to enforce that when a user tries to access the onnx model path, the compressed model is downloaded and unzipped and the reference to the model path points only to the extracted `model.onnx` file where applicable

**note - any users who have already tried to download models with external data will need to clear them from cache**

**test_plan:**
Manually verified with both an external model and a legacy model (see below) - would be good to add these as unit tests, however the download times for the external models can take a while as they are >2Gb. Existing functionality should be thoroughly covered in sparsezoo, deepsparse, and sparseml testing

```python
from sparsezoo import Model
import onnx

large_model_zoo = Model("zoo:nlg/text_generation/opt-1.3b/pytorch/huggingface/opt_pretrain/quantW8A8-none")
small_model_zoo = Model("zoo:cv/classification/vgg-19/pytorch/sparseml/imagenet/pruned-moderate")

large_model_onnx = onnx.load(large_model_zoo.onnx_model.path)
small_model_onnx = onnx.load(small_model_zoo.onnx_model.path)
```