### PR TITLE
[Bugfix] Point OnnxGz files to `model.onnx` but download and extract `model.onnx.tar.gz`

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -157,7 +157,7 @@ class Model(Directory):
             stub_params=self.stub_params,
         )
 
-        self._onnx_gz: Directory = self._directory_from_files(
+        self._onnx_gz: OnnxGz = self._directory_from_files(
             files, directory_class=OnnxGz, display_name="model.onnx.tar.gz"
         )
         self.onnx_model: File = (
@@ -452,7 +452,7 @@ class Model(Directory):
     def _get_directory(
         self,
         file: Dict[str, Any],
-        directory_class: Directory,
+        directory_class: type(Directory),
         display_name: Optional[str] = None,
         regex: Optional[bool] = False,
         **kwargs,
@@ -587,12 +587,12 @@ class Model(Directory):
         regex: Optional[bool] = False,
         allow_multiple_outputs: Optional[bool] = False,
         **kwargs: object,
-    ) -> Union[Directory, None]:
+    ) -> Union[List[Union[Directory, Any, None]], List[Directory], None]:
 
         # Takes a list of file dictionaries and returns
         # a Directory() object, if successful,
         # otherwise None.
-        if all([file_dict.get("file_type") for file_dict in files]):
+        if all(file_dict.get("file_type") for file_dict in files):
             # if file_dict is retrieved from the API as `request_json`
             # first check if a directory can be created from the
             # "loose" files (alternative to parsing a .tar.gz file as

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -369,4 +369,5 @@ class OnnxGz(Directory):
             if not unzipped_file_path.exists():
                 _LOGGER.info(f"{unzipped_file_path} does not exist, was it extracted?")
                 self.is_archive = True
+                return
         self.is_archive = False

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -301,8 +301,9 @@ class OnnxGz(Directory):
     def path(self):
         """
         Assumptions:
-            - the tarball contains only one onnx model, with the
-                name `model.onnx`
+            - the tarball must contain atleast one `model.onnx` file
+            - the tarball may or may not contain additional external data or
+                onnx model file(s)
             - the tarball will be extracted to the same directory as the tarball
 
         :post-condition: self._path will point to the path of the extracted
@@ -367,7 +368,7 @@ class OnnxGz(Directory):
         for zipped_filename in tarfile.open(model_gz_path).getnames():
             unzipped_file_path = expected_path.with_name(zipped_filename)
             if not unzipped_file_path.exists():
-                _LOGGER.info(f"{unzipped_file_path} does not exist, was it extracted?")
+                _LOGGER.debug(f"{unzipped_file_path} does not exist, was it extracted?")
                 self.is_archive = True
                 return
         self.is_archive = False

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -65,7 +65,7 @@ class Directory(File):
             name=name, path=path, url=url, parent_directory=parent_directory
         )
 
-        if self._unpack():
+        if self._unpack() or force:
             self.unzip(force=force)
 
     @classmethod
@@ -284,9 +284,15 @@ class Directory(File):
             )
 
         name = ".".join(self.name.split(".")[:-2])
-        path = os.path.join(extract_directory, name)
-
-        if not os.path.exists(path) or force:  # do not re-unzip if not forced
+        is_model_gz = name == "model.onnx"
+        path = (
+            extract_directory if is_model_gz else os.path.join(extract_directory, name)
+        )
+        # if is_model_gz then path would point to the tarfile(s)
+        # parent directory and must be unzipped irrespective of existence
+        if (
+            is_model_gz or not os.path.exists(path) or force
+        ):  # do not re-unzip if not forced
             tar = tarfile.open(self._path, "r")
             for member in tar.getmembers():
                 member.name = os.path.basename(member.name)

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -346,7 +346,7 @@ def is_directory(file: File) -> bool:
 def _possibly_convert_files_to_directories(files: List[File]) -> List[File]:
     return [
         Directory.from_file(file)
-        if (is_directory(file) and not isinstance(file, Directory))
+        if not isinstance(file, Directory) and is_directory(file)
         else file
         for file in files
     ]

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -304,7 +304,8 @@ class TestModel:
 @pytest.mark.parametrize(
     "stub",
     [
-        "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",
+        "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/"
+        "imagenet/pruned-moderate",
     ],
 )
 def test_model_gz_extraction_from_stub(stub: str):
@@ -318,7 +319,8 @@ def test_model_gz_extraction_from_stub(stub: str):
 @pytest.mark.parametrize(
     "stub",
     [
-        "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",
+        "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/"
+        "imagenet/pruned-moderate",
     ],
 )
 def test_model_gz_extraction_from_local_files(stub: str):

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -115,11 +115,7 @@ def check_extraneous_files(expected_files, temp_dir):
     extraneous_files = set()
     for file in extra_files:
         # ignore model.onnx.tar.gz and model.data files
-        if (
-                "model.onnx.tar.gz" in file
-                or "model.data" in file
-                or "model.md" in file
-        ):
+        if "model.onnx.tar.gz" in file or "model.data" in file or "model.md" in file:
             continue
         extraneous_files.add(file)
     assert not extra_files, f"Extraneous files found: {extraneous_files}"

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -150,13 +150,29 @@ class TestSetupModel:
             recipes=recipes_path,
         )
 
-        assert {
+        files_in_directory = set(os.listdir(temp_dir.name))
+        expected_files = {
             "training",
             "deployment",
             "recipe",
             "model.onnx",
             "sample_inputs.tar.gz",
-        } == set(os.listdir(temp_dir.name))
+        }
+
+        extra_files = files_in_directory - expected_files
+        extraneous_files = set()
+        for file in extra_files:
+            # ignore model.onnx.tar.gz and model.data files
+            if  (
+                    "model.onnx.tar.gz" in file
+                    or "model.data" in file
+                    or "model.md" in file
+            ):
+                continue
+            extraneous_files.add(file)
+
+        assert not extra_files, f"Extraneous files found: {extraneous_files}"
+
 
     def test_setup_model_from_objects(self, setup):
         stub, temp_dir, download_dir = setup

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -127,7 +127,7 @@ def check_extraneous_files(expected_files, temp_dir, ignore_external_data):
         (
             "zoo:nlp/question_answering/distilbert-none/pytorch/"
             "huggingface/squad/pruned80_quant-none-vnni",
-            True,
+            False,
         ),
     ],
 )
@@ -172,6 +172,7 @@ class TestSetupModel:
             "deployment",
             "recipe",
             "model.onnx",
+            "model.onnx.tar.gz",
             "sample_inputs.tar.gz",
         }
 
@@ -204,6 +205,7 @@ class TestSetupModel:
             "deployment",
             "recipe",
             "model.onnx",
+            "model.onnx.tar.gz",
             "sample_inputs",
         }
         check_extraneous_files(expected_files, temp_dir, ignore_external_data)

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -109,6 +109,22 @@ def test_load_files_from_stub(stub, expected_files):
     assert repo_namespace is not None
 
 
+def check_extraneous_files(expected_files, temp_dir):
+    files_in_directory = set(os.listdir(temp_dir.name))
+    extra_files = files_in_directory - expected_files
+    extraneous_files = set()
+    for file in extra_files:
+        # ignore model.onnx.tar.gz and model.data files
+        if (
+                "model.onnx.tar.gz" in file
+                or "model.data" in file
+                or "model.md" in file
+        ):
+            continue
+        extraneous_files.add(file)
+    assert not extra_files, f"Extraneous files found: {extraneous_files}"
+
+
 @pytest.mark.parametrize(
     "stub",
     [
@@ -150,7 +166,6 @@ class TestSetupModel:
             recipes=recipes_path,
         )
 
-        files_in_directory = set(os.listdir(temp_dir.name))
         expected_files = {
             "training",
             "deployment",
@@ -159,19 +174,7 @@ class TestSetupModel:
             "sample_inputs.tar.gz",
         }
 
-        extra_files = files_in_directory - expected_files
-        extraneous_files = set()
-        for file in extra_files:
-            # ignore model.onnx.tar.gz and model.data files
-            if (
-                "model.onnx.tar.gz" in file
-                or "model.data" in file
-                or "model.md" in file
-            ):
-                continue
-            extraneous_files.add(file)
-
-        assert not extra_files, f"Extraneous files found: {extraneous_files}"
+        check_extraneous_files(expected_files, temp_dir)
 
     def test_setup_model_from_objects(self, setup):
         stub, temp_dir, download_dir = setup
@@ -195,11 +198,12 @@ class TestSetupModel:
             recipes=recipes,
         )
 
-        assert {
+        expected_files = {
             "training",
             "deployment",
             "recipe",
             "model.onnx",
             "sample_inputs",
-        } == set(os.listdir(temp_dir.name))
+        }
+        check_extraneous_files(expected_files, temp_dir)
         download_dir.cleanup()

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -163,16 +163,15 @@ class TestSetupModel:
         extraneous_files = set()
         for file in extra_files:
             # ignore model.onnx.tar.gz and model.data files
-            if  (
-                    "model.onnx.tar.gz" in file
-                    or "model.data" in file
-                    or "model.md" in file
+            if (
+                "model.onnx.tar.gz" in file
+                or "model.data" in file
+                or "model.md" in file
             ):
                 continue
             extraneous_files.add(file)
 
         assert not extra_files, f"Extraneous files found: {extraneous_files}"
-
 
     def test_setup_model_from_objects(self, setup):
         stub, temp_dir, download_dir = setup


### PR DESCRIPTION
Big LLMS are generally saved with external data; this external data along with model.onnx live inside `model.onnx.tar.gz` tarball on sparsezoo; recently we added support to download the tarfile and emulate a normal onnx model file using a wrapper class `OnnxGz`; when adding this support a bug was introduced where `model.onnx` was present twice in the model path; leading to errors while creating ort sessions as 


### TEST PLAN:

- [X] Manual inspection using attached script
- [X] Add automated tests to capture conditions where extraction was failing
- [X] Test with deepsparse main

Test Script:
```
from sparsezoo import Model
from pathlib import Path


def local_test(stub: str):
    model = Model(stub)
    onnx_model = model.onnx_model
    model_path = onnx_model.path
    onnx_model_path = Path(model_path)
    assert onnx_model_path.exists(), "Path to onnx model does not exist"
    assert (count := str(onnx_model_path).count("model.onnx")) == 1, f"Path to onnx model contains model.onnx {count} times"

    # create an ORT session with the model
    import onnxruntime as ort
    session = ort.InferenceSession(str(onnx_model_path), providers=["CPUExecutionProvider"])
    assert session is not None, "ORT session is None"

if __name__ == '__main__':
    # stub = "zoo:nlg/text_generation/opt-13b/pytorch/huggingface/opt_pretrain/pruned50_quantW8A8-none"
    stub = "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned_quant-moderate"
    local_test(stub=stub)
```

Before this PR: The onnx_model_path had an extra model.onnx in it's path leading to errors like:
https://github.com/neuralmagic/deepsparse/actions/runs/5869604261/job/15914935604?pr=1150#step:7:138

After this PR the test script runs successfully, and the base test errors on deepsparse side are green

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205276886236935