### PR TITLE
Also Extract model.onnx.tar.gz on Model download

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -236,17 +236,17 @@ class Model(Directory):
     def path(self) -> str:
         """
         Download(if not already downloaded) and return the local path of the model
-        
+
         :return: the local path of the model
         """
         # download the model if not already downloaded
         super().path
-        
+
         # extract onnx_model if it is a tar.gz
         self.onnx_model.path
-        
+
         return self._path
-    
+
     def generate_outputs(
         self, engine_type: str, save_to_tar: bool = False
     ) -> Generator[List[numpy.ndarray], None, None]:
@@ -310,7 +310,7 @@ class Model(Directory):
                             f"but it is `None`. The file is being skipped..."
                         )
             # extract the onnx model if needed
-            self.onnx_model.path    
+            self.onnx_model.path
 
         return all(downloads)
 

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -232,6 +232,21 @@ class Model(Directory):
         """
         return self._stub_params
 
+    @property
+    def path(self) -> str:
+        """
+        Download(if not already downloaded) and return the local path of the model
+        
+        :return: the local path of the model
+        """
+        # download the model if not already downloaded
+        super().path
+        
+        # extract onnx_model if it is a tar.gz
+        self.onnx_model.path
+        
+        return self._path
+    
     def generate_outputs(
         self, engine_type: str, save_to_tar: bool = False
     ) -> Generator[List[numpy.ndarray], None, None]:
@@ -294,6 +309,8 @@ class Model(Directory):
                             f"Attempted to download file {key}, "
                             f"but it is `None`. The file is being skipped..."
                         )
+            # extract the onnx model if needed
+            self.onnx_model.path    
 
         return all(downloads)
 


### PR DESCRIPTION
Currently, model.onnx.tar.gz was only extracted when `Model(stub).onnx_model.path` was accessed; this led to a failure in deepsparse: https://github.com/neuralmagic/deepsparse/actions/runs/5895963143/job/16084105769


This PR addresses the failure by auto extracting the onnx_model on download.

The fix proposed was to call `self.onnx_model.path` at the end of `Model` class's `download()` method 

The deepsparse failures pass after this fix;

<img width="410" alt="Screen Shot 2023-08-22 at 1 14 20 PM" src="https://github.com/neuralmagic/sparsezoo/assets/25380596/38109eed-a671-43ff-ac65-5ab25f8d7990">



