### PR TITLE
Add  "available" attribute to recipes

### DIFF
--- a/src/sparsezoo/objects/recipes.py
+++ b/src/sparsezoo/objects/recipes.py
@@ -76,6 +76,9 @@ class Recipes:
                 return recipe
 
         # fallback to first recipe in list
+        if len(self._recipes) == 0:
+            raise ValueError("No recipes found, could not retrieve a default.")
+
         _LOGGER.warning(
             f"No default recipe {self._default_recipe_name} found, falling back to "
             f"first listed recipe {self._recipes[0].name}"

--- a/src/sparsezoo/objects/recipes.py
+++ b/src/sparsezoo/objects/recipes.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 from sparsezoo.objects import File
@@ -50,6 +51,15 @@ class Recipes:
             self._default_recipe_name = "recipe_" + custom_default
 
     @property
+    def available(self) -> Optional[List[str]]:
+        """
+        :return: List of all recipe names, or None if none are available
+        """
+        if len(self._recipes) == 0:
+            return None
+        return [Path(recipe.name).stem for recipe in self._recipes]
+
+    @property
     def recipes(self) -> List:
         """
         :return: The full list of recipes
@@ -67,8 +77,8 @@ class Recipes:
 
         # fallback to first recipe in list
         _LOGGER.warning(
-            "No default recipe {self._default_recipe_name} found, falling back to"
-            "first listed recipe"
+            f"No default recipe {self._default_recipe_name} found, falling back to "
+            f"first listed recipe {self._recipes[0].name}"
         )
         return self._recipes[0]
 

--- a/tests/sparsezoo/objects/test_recipes.py
+++ b/tests/sparsezoo/objects/test_recipes.py
@@ -35,6 +35,11 @@ def test_recipe_getters():
     found_by_name = model.recipes.get_recipe_by_name("does_not_exist.md")
     assert found_by_name is None
 
+    available_recipes = model.recipes.available
+    assert len(available_recipes) == 4
+    assert "recipe_transfer_token_classification" in available_recipes
+    assert "recipe" in available_recipes
+
 
 def test_custom_default():
     custom_default_name = "transfer_text_classification"
@@ -50,3 +55,7 @@ def test_custom_default():
 
     default_recipe = model.recipes.default
     assert default_recipe.name == expected_default_name
+
+    available_recipes = model.recipes.available
+    assert len(available_recipes) == 1
+    assert available_recipes[0] == "recipe_transfer_text_classification"

--- a/tests/sparsezoo/objects/test_recipes.py
+++ b/tests/sparsezoo/objects/test_recipes.py
@@ -14,6 +14,8 @@
 
 import tempfile
 
+import pytest
+
 from sparsezoo.model import Model
 
 
@@ -59,3 +61,12 @@ def test_custom_default():
     available_recipes = model.recipes.available
     assert len(available_recipes) == 1
     assert available_recipes[0] == "recipe_transfer_text_classification"
+
+
+def test_fail_default_on_empty():
+    false_recipe_stub = "zoo:bert-base-wikipedia_bookcorpus-pruned90?recipe=nope"
+    temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+    model = Model(false_recipe_stub, temp_dir.name)
+
+    with pytest.raises(ValueError):
+        _ = model.recipes.default


### PR DESCRIPTION
Fixes the error in this Asana ticket: https://app.asana.com/0/1204322589046915/1205549265505143/f

Adds an `available` attribute to `Recipes` that provides a list of recipe names. This is needed by the `sparsify.run` sparse transfer

### Testing
Confirmed the command failing in the ticket runs:
```
sparsify.run sparse-transfer --use-case image-classification --data imagenette --optim-level 0.5
```
Also updated unit tests to test the new property