### PR TITLE
Fix download path

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -751,9 +751,7 @@ class Model(Directory):
             return None
         else:
             files = [
-                File.from_dict(
-                    file, parent_directory=os.path.join(parent_directory, display_name)
-                )
+                File.from_dict(file, parent_directory=parent_directory)
                 for file in files
             ]
             directory = directory_class(

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -85,9 +85,7 @@ class File:
     @property
     def path(self):
         if self._path is None:
-            expected_path = os.path.join(
-                self.parent_directory, os.path.basename(self.name)
-            )
+            expected_path = os.path.join(self.parent_directory, self.name)
             if os.path.exists(expected_path):
                 self._path = expected_path
                 return expected_path
@@ -144,7 +142,7 @@ class File:
                     "Please make sure that `destination_path` argument is not None."
                 )
 
-        new_file_path = os.path.join(destination_path, os.path.basename(self.name))
+        new_file_path = os.path.join(destination_path, self.name)
 
         if self.url is None:
             raise ValueError(

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -84,7 +84,6 @@ class File:
 
     @property
     def path(self):
-        breakpoint()
         if self._path is None:
             expected_path = os.path.join(
                 self.parent_directory, os.path.basename(self.name)

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -84,8 +84,11 @@ class File:
 
     @property
     def path(self):
+        breakpoint()
         if self._path is None:
-            expected_path = os.path.join(self.parent_directory, self.name)
+            expected_path = os.path.join(
+                self.parent_directory, os.path.basename(self.name)
+            )
             if os.path.exists(expected_path):
                 self._path = expected_path
                 return expected_path
@@ -142,7 +145,7 @@ class File:
                     "Please make sure that `destination_path` argument is not None."
                 )
 
-        new_file_path = os.path.join(destination_path, self.name)
+        new_file_path = os.path.join(destination_path, os.path.basename(self.name))
 
         if self.url is None:
             raise ValueError(


### PR DESCRIPTION
Before: `.../stub/directory/directory/model.onnx`
After: `.../stub/directory/model.onnx`

Unblocks https://github.com/neuralmagic/deepsparse/pull/1247

```
epsparse$ pytest '/home/george/nm/deepsparse/tests/utils/test_engine_mocking.py'
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/george/nm/deepsparse
configfile: pyproject.toml
plugins: flaky-3.7.0
collected 7 items                                                              

tests/utils/test_engine_mocking.py .......                               [100%]

=============================== warnings summary ===============================
../../../../usr/lib/python3/dist-packages/requests/__init__.py:89
  /usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (2.0.5) or chardet (3.0.4) doesn't match a supported version!
    warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "

../../.local/lib/python3.8/site-packages/urllib3/poolmanager.py:315: 4 warnings
tests/utils/test_engine_mocking.py: 7 warnings
  /home/george/.local/lib/python3.8/site-packages/urllib3/poolmanager.py:315: DeprecationWarning: The 'strict' parameter is no longer needed on Python 3+. This will raise an error in urllib3 v2.1.0.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 7 passed, 12 warnings in 3.96s ========================
(.venv) george@quad-mle-2:~/nm/deepsparse$ 
```