### PR TITLE
[Bugfix] Remove extraneous doctest import

### DIFF
--- a/src/sparsezoo/deployment_package/main.py
+++ b/src/sparsezoo/deployment_package/main.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import doctest
-
 
 __all__ = [
     "deployment_package",
@@ -59,7 +57,3 @@ def deployment_package(
         "stub": stub,
         "metrics": metrics,
     }
-
-
-if __name__ == "__main__":
-    doctest.testmod()


### PR DESCRIPTION
Removes extraneous doctest import in `src/sparsezoo/deployment_package/main.py` The file did not have any doctests anyway.

Asana Ticket:
https://app.asana.com/0/1203126676641557/1205661171135072/f