### PR TITLE
model.deployment to target compressed deployment directory

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -224,6 +224,20 @@ class Model(Directory):
         self.integration_validator = IntegrationValidator(model=self)
 
     @property
+    def deployment_directory_path(self) -> str:
+        """
+        :return: file path of uncompressed deployemnt directory. Both (1) downloads
+            compressed deployemnent directory if not downloaded (2) uncompresses
+            deployment directory if compressed
+        """
+        # trigger initial download if not downloaded
+        self.deployment.path
+        if self.deployment.is_archive:
+            self.deployment.unzip()
+
+        return self.deployment.path
+
+    @property
     def stub_params(self) -> Dict[str, str]:
         """
         :return: mapping of variable name to value for query params in zoo stub

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -39,6 +39,7 @@ from sparsezoo.objects import (
     SelectDirectory,
     is_directory,
 )
+from sparsezoo.objects.directories import AliasedSelectDirectory
 from sparsezoo.utils import DataLoader
 from sparsezoo.validation import IntegrationValidator
 
@@ -137,10 +138,11 @@ class Model(Directory):
             files, directory_class=Directory, display_name="sample-labels"
         )
 
-        self.deployment: SelectDirectory = self._directory_from_files(
+        self.deployment: AliasedSelectDirectory = self._directory_from_files(
             files,
-            directory_class=SelectDirectory,
-            display_name="deployment.tar.gz",
+            directory_class=AliasedSelectDirectory,
+            display_name="deployment",
+            download_alias="deployment.tar.gz",
             stub_params=self.stub_params,
         )
 

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -140,7 +140,7 @@ class Model(Directory):
         self.deployment: SelectDirectory = self._directory_from_files(
             files,
             directory_class=SelectDirectory,
-            display_name="deployment",
+            display_name="deployment.tar.gz",
             stub_params=self.stub_params,
         )
 

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -31,6 +31,7 @@ from sparsezoo.model.utils import (
     save_outputs_to_tar,
 )
 from sparsezoo.objects import (
+    AliasedSelectDirectory,
     Directory,
     File,
     NumpyDirectory,
@@ -39,7 +40,6 @@ from sparsezoo.objects import (
     SelectDirectory,
     is_directory,
 )
-from sparsezoo.objects.directories import AliasedSelectDirectory
 from sparsezoo.utils import DataLoader
 from sparsezoo.validation import IntegrationValidator
 

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -388,12 +388,13 @@ def restructure_request_json(
     # use `sample-inputs.tar.gz` to simulate non-existent directories
 
     files_to_create = [
+        "deployment.tar.gz",
         "sample-inputs.tar.gz",
         "sample-labels.tar.gz",
         "sample-originals.tar.gz",
         "sample-outputs.tar.gz",
     ]
-    types = ["inputs", "labels", "originals", "outputs"]
+    types = ["deployment", "inputs", "labels", "originals", "outputs"]
     for file_name, type in zip(files_to_create, types):
         data = fetch_from_request_json(
             request_json, "display_name", file_name.replace("_", "-")


### PR DESCRIPTION
to land with https://github.com/neuralmagic/deepsparse/pull/1318

updates `Model` to target the compressed deployment directory tarball instead of the loose directory
includes a helper function for downloading/unzipping the tarball

**simple test:**
```python
from sparsezoo import Model

model = Model("zoo:nlg/text_generation/mpt-7b/pytorch/huggingface/mpt_chat/base-none")

model.deployment_directory_path
```


This PR adds a `AliasedSelectDirectory` class that can be used to download a different file, but point to the actual expected directory.


Now, the deployment folder is always downloaded as a tar ball and extracted instead of downloading all files.

Test:
```python
# local_test.py
from sparsezoo import Model

stub = "zoo:resnet_v1-50-imagenet-pruned95_quantized"

model = Model(stub)

print(model.deployment.path)
```


Case 1: When model is not already downloaded:

```bash

rahul at office-desktop in ~/projects/sparsezoo (deployment-tar●●) (.venv) 
$ rm -rf ~/.cache/sparsezoo                                                                                                   (deployment-tar|✚3…3)

rahul at office-desktop in ~/projects/sparsezoo (deployment-tar●●) (.venv) 
$ python local_test.py                                                                                                        (deployment-tar|✚3…3)
Downloading (…)eployment/model.onnx: 100%|█████████████████████████████████████████████████████████████████████| 30.3M/30.3M [00:02<00:00, 12.5MB/s]
Downloading (…)quantized/model.onnx: 100%|█████████████████████████████████████████████████████████████████████| 30.3M/30.3M [00:02<00:00, 12.3MB/s]
/home/rahul/.cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned95_quantized/deployment

rahul at office-desktop in ~/projects/sparsezoo (deployment-tar●●) (.venv) 
$ tree /home/rahul/.cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned95_quantized                                      (deployment-tar|✚3…3)
/home/rahul/.cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned95_quantized
├── deployment
│   └── model.onnx
└── model.onnx
```

Case 2: When the files are already downloaded

```bash
rahul at office-desktop in ~/projects/sparsezoo (deployment-tar●●) (.venv) 
$ tree /home/rahul/.cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned95_quantized                                      (deployment-tar|✚3…3)
/home/rahul/.cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned95_quantized
├── deployment
│   └── model.onnx
└── model.onnx

1 directory, 2 files

rahul at office-desktop in ~/projects/sparsezoo (deployment-tar●●) (.venv) 
$ python local_test.py                                                                                                        (deployment-tar|✚3…3)
/home/rahul/.cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned95_quantized/deployment

rahul at office-desktop in ~/projects/sparsezoo (deployment-tar●●) (.venv) 
$ tree /home/rahul/.cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned95_quantized                                      (deployment-tar|✚3…3)
/home/rahul/.cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned95_quantized
├── deployment
│   └── model.onnx
└── model.onnx

1 directory, 2 files
```