### PR TITLE
Enable the easy download of the deployment.tar.gz

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -201,6 +201,7 @@ class Model(Directory):
         self._files_dictionary = {
             "training": self.training,
             "deployment": self.deployment,
+            "deployment.tar.gz": self.deployment_tar,
             "onnx_folder": self.onnx_folder,
             "logs": self.logs,
             "sample_originals": self.sample_originals,
@@ -242,7 +243,7 @@ class Model(Directory):
         if self.deployment_tar.is_archive:
             self.deployment_tar.unzip()
 
-        return self.deployment_tar.path
+        return self.deployment.path
 
     @property
     def stub_params(self) -> Dict[str, str]:

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -145,6 +145,14 @@ class Model(Directory):
             allow_multiple_outputs=True,
         )
 
+        if isinstance(self.deployment, list):
+            # if there are multiple deployment directories
+            # (this may happen due to the presence of both
+            # - deployment directory
+            # - deployment.tar.gz file
+            # we need to choose one (they are identical)
+            self.deployment = self.deployment[0]
+
         self.deployment_tar: SelectDirectory = self._directory_from_files(
             files,
             directory_class=SelectDirectory,
@@ -668,7 +676,7 @@ class Model(Directory):
         # one directory (unless `allow-multiple_outputs`=True)
         elif len(directories_found) != 1:
             if allow_multiple_outputs:
-                return directories_found[0]
+                return directories_found
             raise ValueError(
                 f"Found more than one Directory for `display_name`: {display_name}."
             )

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -324,6 +324,12 @@ class Model(Directory):
         else:
             downloads = []
             for key, file in self._files_dictionary.items():
+                if key == "deployment":
+                    # skip the download of the deployment directory
+                    # since identical files will be downloaded
+                    # in the deployment_tar
+                    _LOGGER.debug(f"Intentionally skipping downloading the file {key}")
+                    continue
                 if file is not None:
                     # save all the files to a temporary directory
                     downloads.append(self._download(file, download_path))

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -142,6 +142,13 @@ class Model(Directory):
             directory_class=SelectDirectory,
             display_name="deployment",
             stub_params=self.stub_params,
+            allow_multiple_outputs=True,
+        )
+
+        self.deployment_tar: SelectDirectory = self._directory_from_files(
+            files,
+            directory_class=SelectDirectory,
+            display_name="deployment.tar.gz",
         )
 
         self.onnx_folder: Directory = self._directory_from_files(
@@ -222,6 +229,20 @@ class Model(Directory):
         )
 
         self.integration_validator = IntegrationValidator(model=self)
+
+    @property
+    def deployment_directory_path(self) -> str:
+        """
+        :return: file path of uncompressed deployemnt directory. Both (1) downloads
+            compressed deployemnent directory if not downloaded (2) uncompresses
+            deployment directory if compressed
+        """
+        # trigger initial download if not downloaded
+        self.deployment_tar.path
+        if self.deployment_tar.is_archive:
+            self.deployment_tar.unzip()
+
+        return self.deployment_tar.path
 
     @property
     def stub_params(self) -> Dict[str, str]:
@@ -646,7 +667,7 @@ class Model(Directory):
         # one directory (unless `allow-multiple_outputs`=True)
         elif len(directories_found) != 1:
             if allow_multiple_outputs:
-                return directories_found
+                return directories_found[0]
             raise ValueError(
                 f"Found more than one Directory for `display_name`: {display_name}."
             )

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -388,12 +388,13 @@ def restructure_request_json(
     # use `sample-inputs.tar.gz` to simulate non-existent directories
 
     files_to_create = [
+        "deployment.tar.gz",
         "sample-inputs.tar.gz",
         "sample-labels.tar.gz",
         "sample-originals.tar.gz",
         "sample-outputs.tar.gz",
     ]
-    types = ["inputs", "labels", "originals", "outputs"]
+    types = ["deployment", "inputs", "labels", "originals", "outputs"]
     for file_name, type in zip(files_to_create, types):
         data = fetch_from_request_json(
             request_json, "display_name", file_name.replace("_", "-")

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -298,9 +298,22 @@ class Directory(File):
                 member.name = os.path.basename(member.name)
                 tar.extract(member=member, path=path)
                 files.append(
-                    File(name=member.name, path=os.path.join(path, member.name))
+                    File(
+                        name=member.name,
+                        path=os.path.join(path, member.name),
+                        parent_directory=path,
+                    )
                 )
             tar.close()
+        # if path already exists, then the tar archive has already been unzipped
+        # and we can just use the files in the directory
+        elif os.path.exists(path):
+            for file in os.listdir(path):
+                files.append(
+                    File(
+                        name=file, path=os.path.join(path, file), parent_directory=path
+                    )
+                )
 
         self.name = name
         self.files = files

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -357,7 +357,7 @@ def test_model_deployment_directory(tmpdir, stub):
 
     assert isinstance(model.deployment, SelectDirectory)
     # TODO: this should be 1. However, the API is returning for `deployment` file type
-    # both `model.onnx` and `deployment/model.onnx`. T
+    # both `model.onnx` and `deployment/model.onnx`.
     # This should probably be fixed on the API side
     assert (
         len(model.deployment.files) == 2

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -348,7 +348,7 @@ def test_model_deployment_directory(tmpdir, stub):
 
     # deployment and deployment_tar should be point to the same files
     assert deployment_dir_path == model.deployment_tar.path == model.deployment.path
-    # make sure that the model contains expectedd files
+    # make sure that the model contains expected files
     assert set(os.listdir(tmpdir.strpath)) == {"deployment.tar.gz", "deployment"}
     assert (
         os.listdir(os.path.join(tmpdir.strpath, "deployment"))

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -338,10 +338,11 @@ def test_model_gz_extraction_from_local_files(stub: str):
         "imagenet/pruned-moderate",
     ],
 )
-def test_model_deployment_directory(tmpdir, stub):
+def test_model_deployment_directory(stub):
+    temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
     expected_deployment_files = ["model.onnx"]
 
-    model = Model(stub, tmpdir)
+    model = Model(stub, temp_dir.name)
     assert model.deployment_tar.is_archive
     # download and extract deployment tar
     deployment_dir_path = model.deployment_directory_path
@@ -349,9 +350,9 @@ def test_model_deployment_directory(tmpdir, stub):
     # deployment and deployment_tar should be point to the same files
     assert deployment_dir_path == model.deployment_tar.path == model.deployment.path
     # make sure that the model contains expected files
-    assert set(os.listdir(tmpdir.strpath)) == {"deployment.tar.gz", "deployment"}
+    assert set(os.listdir(temp_dir.name)) == {"deployment.tar.gz", "deployment"}
     assert (
-        os.listdir(os.path.join(tmpdir.strpath, "deployment"))
+        os.listdir(os.path.join(temp_dir.name, "deployment"))
         == expected_deployment_files
     )
 
@@ -368,7 +369,7 @@ def test_model_deployment_directory(tmpdir, stub):
     assert not model.deployment_tar.is_archive
 
     # test recreating the model from the local files
-    model = Model(tmpdir.strpath)
+    model = Model(temp_dir.name)
 
     assert isinstance(model.deployment, SelectDirectory)
     assert len(model.deployment.files) == len(expected_deployment_files)
@@ -377,7 +378,7 @@ def test_model_deployment_directory(tmpdir, stub):
     assert len(model.deployment_tar.files) == len(expected_deployment_files)
     assert not model.deployment_tar.is_archive
 
-    shutil.rmtree(tmpdir.dirname)
+    shutil.rmtree(temp_dir.name)
 
 
 def _extraction_test_helper(model: Model):

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -184,6 +184,10 @@ class TestModel:
         temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
         model = Model(stub, temp_dir.name)
         model.download()
+        # since downloading the `deployment` file is
+        # disabled by default, we need to do it
+        # explicitly
+        model.deployment.download()
         self._add_mock_files(temp_dir.name, clone_sample_outputs=clone_sample_outputs)
         model = Model(temp_dir.name)
 

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -340,7 +340,7 @@ def test_model_gz_extraction_from_local_files(stub: str):
 )
 def test_model_deployment_directory(tmpdir, stub):
     model = Model(stub, tmpdir)
-    assert model.deployment_tar.is_archive == True
+    assert model.deployment_tar.is_archive
     # download and extract deployment tar
     deployment_dir_path = model.deployment_directory_path
     assert deployment_dir_path == model.deployment_tar.path == model.deployment.path
@@ -352,7 +352,7 @@ def test_model_deployment_directory(tmpdir, stub):
 
     assert isinstance(model.deployment_tar, SelectDirectory)
     assert len(model.deployment_tar.files) == 1
-    assert model.deployment_tar.is_archive == False
+    assert not model.deployment_tar.is_archive
 
     model = Model(tmpdir.strpath)
     assert isinstance(model.deployment, SelectDirectory)

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -358,7 +358,7 @@ def test_model_deployment_directory(tmpdir, stub):
     assert isinstance(model.deployment, SelectDirectory)
     # TODO: this should be 1. However, the API is returning for `deployment` file type
     # both `model.onnx` and `deployment/model.onnx`. T
-    # his should probably fix on the API side
+    # This should probably be fixed on the API side
     assert (
         len(model.deployment.files) == 2
     )  # should be == len(expected_deployment_files)


### PR DESCRIPTION
Reverting to the state of #375 in order to enable, in the simplest way possible, the fetching of only `deployment.tar.gz`.
The crux of this PR is adding `self.deployment_tar` attribute to the `Model` and allowing it to be correctly initialized not only from the stub but also from the local directory.
Added unit tests that test this feature.

Manual tests:

```python
path_where_models_are = "/home/ubuntu/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized"
if os.path.exists(path_where_models_are):
    shutil.rmtree(path_where_models_are)
    print(f"The path {path_where_models_are} has been cleaned up")
else:
    print(f"The path {path_where_models_are} does not exist")


print("1: Creating the deployment from stub")
model = Model("zoo:codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized")
# local path to the `deployment.tar.gz` should be None (we have not downloaded anything yet)
print("Deployment directory tar path (before download): ", model.deployment_tar._path)
# grab the deployment_dir_path (this downloads the deployment.tar.gz and unpacks it)
deployment_dir_path = model.deployment_directory_path

# all should be pointing to `directory`
assert deployment_dir_path == model.deployment_tar.path == model.deployment.path
print("Deployment directory tar path: ", model.deployment_tar._path)
print("Deployment directory path: ", model.deployment.path)
print(f"deployment_dir_path: {deployment_dir_path}")

# all should display `directory` files
print("Contents of the deployment tar directory: ", os.listdir(model.deployment_tar.path))
print("Contents of the deployment directory: ", os.listdir(model.deployment.path))

# should only contain `deployment` and `deployment.tar.gz`
print("Contents of the model directory: ", os.listdir(model._path))

print("2: Creating the deployment from local path")
model = Model("zoo:codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized")
print("Deployment directory tar path: ", model.deployment_tar.path)
deployment_dir_path = model.deployment_directory_path

assert deployment_dir_path == model.deployment_tar.path
print("Deployment directory tar path (after unzipping): ", model.deployment_tar._path)
print("Deployment directory path: ", model.deployment.path)
print(f"deployment_dir_path: {deployment_dir_path}")
print("Contents of the deployment tar directory: ", os.listdir(model.deployment_tar.path))
print("Contents of the deployment directory: ", os.listdir(model.deployment.path))
print("Contents of the model directory: ", os.listdir(model._path))
```

out:

```bash
The path /home/ubuntu/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized has been cleaned up
1: Creating the deployment from stub
Deployment directory tar path (before download):  None
Downloading (…)ed/deployment.tar.gz: 100%|██████████| 265M/265M [00:23<00:00, 12.1MB/s]
Deployment directory tar path:  /home/ubuntu/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized/deployment
Deployment directory path:  /home/ubuntu/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized/deployment
deployment_dir_path: /home/ubuntu/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized/deployment
Contents of the deployment tar directory:  ['vocab.json', 'model.onnx', 'config.json', 'merges.txt', 'tokenizer_config.json', 'special_tokens_map.json', 'tokenizer.json']
Contents of the deployment directory:  ['vocab.json', 'model.onnx', 'config.json', 'merges.txt', 'tokenizer_config.json', 'special_tokens_map.json', 'tokenizer.json']
Contents of the model directory:  ['deployment', 'deployment.tar.gz']
2: Creating the deployment from local path
Deployment directory tar path:  /home/ubuntu/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized/deployment.tar.gz
Deployment directory tar path (after unzipping):  /home/ubuntu/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized/deployment
Deployment directory path:  /home/ubuntu/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized/deployment
deployment_dir_path: /home/ubuntu/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-pruned50_quantized/deployment
Contents of the deployment tar directory:  ['vocab.json', 'model.onnx', 'config.json', 'merges.txt', 'tokenizer_config.json', 'special_tokens_map.json', 'tokenizer.json']
Contents of the deployment directory:  ['vocab.json', 'model.onnx', 'config.json', 'merges.txt', 'tokenizer_config.json', 'special_tokens_map.json', 'tokenizer.json']
Contents of the model directory:  ['deployment', 'deployment.tar.gz']
```