### PR TITLE
Allow passing multiple name for registering a value in `RegistryMixin`

### DIFF
--- a/tests/sparsezoo/utils/test_registry.py
+++ b/tests/sparsezoo/utils/test_registry.py
@@ -25,17 +25,30 @@ def test_registery_flow_single():
     class Foo1(Foo):
         pass
 
+    assert {"Foo1"} == set(Foo.registered_names())
+
     @Foo.register(name="name_2")
     class Foo2(Foo):
         pass
 
     assert {"Foo1", "name_2"} == set(Foo.registered_names())
 
-    with pytest.raises(ValueError):
+    @Foo.register(name=["name_3", "name_4"])
+    class Foo3(Foo):
+        pass
+
+    assert {"Foo1", "name_2", "name_3", "name_4"} == set(Foo.registered_names())
+
+    with pytest.raises(KeyError):
         Foo.get_value_from_registry("Foo2")
 
     assert Foo.get_value_from_registry("Foo1") is Foo1
     assert isinstance(Foo.load_from_registry("name_2"), Foo2)
+    assert (
+        Foo.get_value_from_registry("name_3")
+        is Foo3
+        is Foo.get_value_from_registry("name_4")
+    )
 
 
 def test_registry_flow_multiple():


### PR DESCRIPTION
## Feature Description

Allows passing a `List[str]` to the `name` argument:

```python
# register with multiple aliases
@Dataset.register(name=["cifar-10-dataset", "cifar-100-dataset"])
class Cifar(Dataset):
    pass
```
