### PR TITLE
[Cherry-Pick] Enable the easy download of the deployment.tar.gz

### DIFF
--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -298,9 +298,22 @@ class Directory(File):
                 member.name = os.path.basename(member.name)
                 tar.extract(member=member, path=path)
                 files.append(
-                    File(name=member.name, path=os.path.join(path, member.name))
+                    File(
+                        name=member.name,
+                        path=os.path.join(path, member.name),
+                        parent_directory=path,
+                    )
                 )
             tar.close()
+        # if path already exists, then the tar archive has already been unzipped
+        # and we can just use the files in the directory
+        elif os.path.exists(path):
+            for file in os.listdir(path):
+                files.append(
+                    File(
+                        name=file, path=os.path.join(path, file), parent_directory=path
+                    )
+                )
 
         self.name = name
         self.files = files

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -23,10 +23,12 @@ import numpy
 import pytest
 
 from sparsezoo import Model
+from sparsezoo.objects.directories import SelectDirectory
 
 
 files_ic = {
     "training",
+    "deployment.tar.gz",
     "deployment",
     "logs",
     "onnx",
@@ -182,6 +184,10 @@ class TestModel:
         temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
         model = Model(stub, temp_dir.name)
         model.download()
+        # since downloading the `deployment` file is
+        # disabled by default, we need to do it
+        # explicitly
+        model.deployment.download()
         self._add_mock_files(temp_dir.name, clone_sample_outputs=clone_sample_outputs)
         model = Model(temp_dir.name)
 
@@ -326,6 +332,56 @@ def test_model_gz_extraction_from_local_files(stub: str):
     source = temp_dir.name
     model_from_local_files = Model(source)
     _extraction_test_helper(model_from_local_files)
+    shutil.rmtree(temp_dir.name)
+
+
+@pytest.mark.parametrize(
+    "stub",
+    [
+        "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/"
+        "imagenet/pruned-moderate",
+    ],
+)
+def test_model_deployment_directory(stub):
+    temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+    expected_deployment_files = ["model.onnx"]
+
+    model = Model(stub, temp_dir.name)
+    assert model.deployment_tar.is_archive
+    # download and extract deployment tar
+    deployment_dir_path = model.deployment_directory_path
+
+    # deployment and deployment_tar should be point to the same files
+    assert deployment_dir_path == model.deployment_tar.path == model.deployment.path
+    # make sure that the model contains expected files
+    assert set(os.listdir(temp_dir.name)) == {"deployment.tar.gz", "deployment"}
+    assert (
+        os.listdir(os.path.join(temp_dir.name, "deployment"))
+        == expected_deployment_files
+    )
+
+    assert isinstance(model.deployment, SelectDirectory)
+    # TODO: this should be 1. However, the API is returning for `deployment` file type
+    # both `model.onnx` and `deployment/model.onnx`.
+    # This should probably be fixed on the API side
+    assert (
+        len(model.deployment.files) == 2
+    )  # should be == len(expected_deployment_files)
+
+    assert isinstance(model.deployment_tar, SelectDirectory)
+    assert len(model.deployment_tar.files) == len(expected_deployment_files)
+    assert not model.deployment_tar.is_archive
+
+    # test recreating the model from the local files
+    model = Model(temp_dir.name)
+
+    assert isinstance(model.deployment, SelectDirectory)
+    assert len(model.deployment.files) == len(expected_deployment_files)
+
+    assert isinstance(model.deployment_tar, SelectDirectory)
+    assert len(model.deployment_tar.files) == len(expected_deployment_files)
+    assert not model.deployment_tar.is_archive
+
     shutil.rmtree(temp_dir.name)
 
 


### PR DESCRIPTION
Cherry picking https://github.com/neuralmagic/sparsezoo/pull/379 to `release/1.6`. 
The goal is to mitigate the problem with repeated downloads of the `directory` folder, caused by the simultaneous presence of the `deployment` directory and `deployment.tar.gz` file.