### PR TITLE
Clean up relationship between deployment_tar and deployment

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -137,12 +137,18 @@ class Model(Directory):
             files, directory_class=Directory, display_name="sample-labels"
         )
 
+        self.deployment_tar: SelectDirectory = self._directory_from_files(
+            files,
+            directory_class=SelectDirectory,
+            display_name="deployment.tar.gz",
+        )
         self.deployment: SelectDirectory = self._directory_from_files(
             files,
             directory_class=SelectDirectory,
             display_name="deployment",
             stub_params=self.stub_params,
             allow_multiple_outputs=True,
+            tar_directory=self.deployment_tar,
         )
 
         if isinstance(self.deployment, list):
@@ -152,12 +158,6 @@ class Model(Directory):
             # - deployment.tar.gz file
             # we need to choose one (they are identical)
             self.deployment = self.deployment[0]
-
-        self.deployment_tar: SelectDirectory = self._directory_from_files(
-            files,
-            directory_class=SelectDirectory,
-            display_name="deployment.tar.gz",
-        )
 
         self.onnx_folder: Directory = self._directory_from_files(
             files,

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -118,11 +118,9 @@ class Model(Directory):
             files,
             directory_class=NumpyDirectory,
             display_name="sample-inputs",
-            allow_multiple_outputs=True,
+            allow_picking_one_from_multiple=True,
         )
 
-        if isinstance(self.sample_inputs, list):
-            self.sample_inputs = self.sample_inputs[0]
         self.model_card: File = self._file_from_files(files, display_name="model.md")
 
         self.sample_outputs = self._directory_from_files(
@@ -616,6 +614,10 @@ class Model(Directory):
         display_name: Optional[str] = None,
         regex: bool = False,
         allow_multiple_outputs: bool = False,
+        # allow picking one from multiple directories
+        # is used when we initialize the model from
+        # local directory (not stub) and both [some_directory]
+        # and [some_directory].tar.gz are present
         allow_picking_one_from_multiple: bool = False,
         **kwargs: object,
     ) -> Union[List[Union[Directory, Any, None]], List[Directory], None]:

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -246,6 +246,10 @@ class Model(Directory):
             compressed deployemnent directory if not downloaded (2) uncompresses
             deployment directory if compressed
         """
+        # TODO: Can get rid of this as long as we update all references in deepsparse
+        # to now use model.deployment.path/download once we guarantee that it always
+        # goes through tar
+
         # trigger initial download if not downloaded
         self.deployment_tar.path
         if self.deployment_tar.is_archive:

--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -111,14 +111,18 @@ class Model(Directory):
         self.sample_originals: Directory = self._directory_from_files(
             files,
             directory_class=Directory,
+            allow_multiple_outputs=True,
             display_name="sample-originals",
         )
         self.sample_inputs: NumpyDirectory = self._directory_from_files(
             files,
             directory_class=NumpyDirectory,
             display_name="sample-inputs",
+            allow_multiple_outputs=True,
         )
 
+        if isinstance(self.sample_inputs, list):
+            self.sample_inputs = self.sample_inputs[0]
         self.model_card: File = self._file_from_files(files, display_name="model.md")
 
         self.sample_outputs = self._directory_from_files(
@@ -134,7 +138,10 @@ class Model(Directory):
             ] = self._sample_outputs_list_to_dict(self.sample_outputs)
 
         self.sample_labels: Directory = self._directory_from_files(
-            files, directory_class=Directory, display_name="sample-labels"
+            files,
+            directory_class=Directory,
+            allow_multiple_outputs=True,
+            display_name="sample-labels",
         )
 
         self.deployment_tar: SelectDirectory = self._directory_from_files(
@@ -150,6 +157,11 @@ class Model(Directory):
             allow_multiple_outputs=True,
             tar_directory=self.deployment_tar,
         )
+        if isinstance(self.sample_originals, list):
+            self.sample_originals = self.sample_originals[0]
+
+        if isinstance(self.sample_labels, list):
+            self.sample_labels = self.sample_labels[0]
 
         if isinstance(self.deployment, list):
             # if there are multiple deployment directories
@@ -209,7 +221,6 @@ class Model(Directory):
         self._files_dictionary = {
             "training": self.training,
             "deployment": self.deployment,
-            "deployment.tar.gz": self.deployment_tar,
             "onnx_folder": self.onnx_folder,
             "logs": self.logs,
             "sample_originals": self.sample_originals,
@@ -238,24 +249,6 @@ class Model(Directory):
         )
 
         self.integration_validator = IntegrationValidator(model=self)
-
-    @property
-    def deployment_directory_path(self) -> str:
-        """
-        :return: file path of uncompressed deployemnt directory. Both (1) downloads
-            compressed deployemnent directory if not downloaded (2) uncompresses
-            deployment directory if compressed
-        """
-        # TODO: Can get rid of this as long as we update all references in deepsparse
-        # to now use model.deployment.path/download once we guarantee that it always
-        # goes through tar
-
-        # trigger initial download if not downloaded
-        self.deployment_tar.path
-        if self.deployment_tar.is_archive:
-            self.deployment_tar.unzip()
-
-        return self.deployment.path
 
     @property
     def stub_params(self) -> Dict[str, str]:
@@ -328,12 +321,6 @@ class Model(Directory):
         else:
             downloads = []
             for key, file in self._files_dictionary.items():
-                if key == "deployment":
-                    # skip the download of the deployment directory
-                    # since identical files will be downloaded
-                    # in the deployment_tar
-                    _LOGGER.debug(f"Intentionally skipping downloading the file {key}")
-                    continue
                 if file is not None:
                     # save all the files to a temporary directory
                     downloads.append(self._download(file, download_path))
@@ -750,6 +737,8 @@ class Model(Directory):
                 engine_name = directory.name.split("_")[-1]
                 if engine_name.endswith(".tar.gz"):
                     engine_name = engine_name.replace(".tar.gz", "")
+                if engine_name == "sample-outputs":
+                    continue
                 if engine_name not in ENGINES:
                     raise ValueError(
                         f"The name of the 'sample-outputs' directory should "

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -197,6 +197,9 @@ class SelectDirectory(Directory):
     :param parent_directory: path of the parent SelectDirectory
     :param stub_params: dictionary of zoo stub params that this directory
         was specified with
+    :param tar_directory: optional pointer to the tar_directory
+        of this directory. By default, when downloading the directory
+        in question, we should download and extract the tarball.
     """
 
     def __init__(
@@ -207,7 +210,7 @@ class SelectDirectory(Directory):
         url: Optional[str] = None,
         parent_directory: Optional[str] = None,
         stub_params: Optional[Dict[str, str]] = None,
-        tar_directory: Directory = None,
+        tar_directory: Optional[Directory] = None,
     ):
         self._default, self._available = None, None
 

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -218,11 +218,7 @@ class SelectDirectory(Directory):
             url=url,
             parent_directory=parent_directory,
         )
-
-        # TODO: update download and/or path so on download of entire directory
-        # we go through the tar directory
         self.tar_directory = tar_directory
-
         self._stub_params = stub_params or {}
         self.files_dict = self.files_to_dictionary()
 

--- a/src/sparsezoo/objects/directories.py
+++ b/src/sparsezoo/objects/directories.py
@@ -207,6 +207,7 @@ class SelectDirectory(Directory):
         url: Optional[str] = None,
         parent_directory: Optional[str] = None,
         stub_params: Optional[Dict[str, str]] = None,
+        tar_directory: Directory = None,
     ):
         self._default, self._available = None, None
 
@@ -217,6 +218,10 @@ class SelectDirectory(Directory):
             url=url,
             parent_directory=parent_directory,
         )
+
+        # TODO: update download and/or path so on download of entire directory
+        # we go through the tar directory
+        self.tar_directory = tar_directory
 
         self._stub_params = stub_params or {}
         self.files_dict = self.files_to_dictionary()

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -167,7 +167,7 @@ class Directory(File):
                     "Failed to recognize a valid download path. "
                     "Please make sure that `destination_path` argument is not None."
                 )
-        if self.tar_directory is not None:
+        if getattr(self, "tar_directory", None) is not None:
             self = self.tar_directory
 
         # Directory can represent a tar file.

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -168,9 +168,12 @@ class Directory(File):
                     "Please make sure that `destination_path` argument is not None."
                 )
         if getattr(self, "tar_directory", None) is not None:
+            # if tar_directory is not None, then we are downloading
+            # the directory as a tar archive file
             self = self.tar_directory
 
         # Directory can represent a tar file.
+        # In this case, we download the tar file and unzip it.
         if self.is_archive:
             new_file_path = os.path.join(destination_path, self.name)
             for attempt in range(retries):

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -167,6 +167,8 @@ class Directory(File):
                     "Failed to recognize a valid download path. "
                     "Please make sure that `destination_path` argument is not None."
                 )
+        if self.tar_directory is not None:
+            self = self.tar_directory
 
         # Directory can represent a tar file.
         if self.is_archive:
@@ -180,6 +182,7 @@ class Directory(File):
                     )
 
                     self._path = new_file_path
+                    self.unzip()
                     return
 
                 except Exception as err:

--- a/src/sparsezoo/objects/directory.py
+++ b/src/sparsezoo/objects/directory.py
@@ -298,9 +298,22 @@ class Directory(File):
                 member.name = os.path.basename(member.name)
                 tar.extract(member=member, path=path)
                 files.append(
-                    File(name=member.name, path=os.path.join(path, member.name))
+                    File(
+                        name=member.name,
+                        path=os.path.join(path, member.name),
+                        parent_directory=path,
+                    )
                 )
             tar.close()
+        # if path already exists, then the tar archive has already been unzipped
+        # and we can just use the files in the directory
+        elif os.path.exists(path):
+            for file in os.listdir(path):
+                files.append(
+                    File(
+                        name=file, path=os.path.join(path, file), parent_directory=path
+                    )
+                )
 
         self.name = name
         self.files = files

--- a/src/sparsezoo/objects/file.py
+++ b/src/sparsezoo/objects/file.py
@@ -95,7 +95,7 @@ class File:
         elif not os.path.exists(self._path):
             self.download()
 
-        return self._path
+        return self._path or self.path
 
     @classmethod
     def from_dict(

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -61,40 +61,40 @@ files_yolo = copy.copy(files_ic)
             ("recipe", "transfer_learn"),
             True,
         ),
-        (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
-            "pruned-moderate",
-            ("checkpoint", "some_dummy_name"),
-            False,
-        ),
-        (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
-            "pruned-moderate",
-            ("deployment", "default"),
-            True,
-        ),
-        (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
-            "pruned-moderate",
-            ("checkpoint", "preqat"),
-            True,
-        ),
-        (
-            "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/"
-            "12layer_pruned80_quant-none-vnni",
-            ("checkpoint", "postqat"),
-            True,
-        ),
-        (
-            "biobert-base_cased-jnlpba_pubmed-pruned80.4block_quantized",
-            ("deployment", "default"),
-            True,
-        ),
-        (
-            "resnet_v1-50-imagenet-pruned95",
-            ("checkpoint", "preqat"),
-            True,
-        ),
+        # (
+        #     "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+        #     "pruned-moderate",
+        #     ("checkpoint", "some_dummy_name"),
+        #     False,
+        # ),
+        # (
+        #     "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+        #     "pruned-moderate",
+        #     ("deployment", "default"),
+        #     True,
+        # ),
+        # (
+        #     "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+        #     "pruned-moderate",
+        #     ("checkpoint", "preqat"),
+        #     True,
+        # ),
+        # (
+        #     "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/"
+        #     "12layer_pruned80_quant-none-vnni",
+        #     ("checkpoint", "postqat"),
+        #     True,
+        # ),
+        # (
+        #     "biobert-base_cased-jnlpba_pubmed-pruned80.4block_quantized",
+        #     ("deployment", "default"),
+        #     True,
+        # ),
+        # (
+        #     "resnet_v1-50-imagenet-pruned95",
+        #     ("checkpoint", "preqat"),
+        #     True,
+        # ),
     ],
     scope="function",
 )
@@ -142,39 +142,39 @@ class TestSetupModel:
             True,
             files_ic.union({"recipe.md", "recipe_transfer_learn.md"}),
         ),
-        (
-            (
-                "zoo:"
-                "nlp/question_answering/distilbert-none/"
-                "pytorch/huggingface/squad/pruned80_quant-none-vnni"
-            ),
-            False,
-            files_nlp.union({"recipe.md"}),
-        ),
-        (
-            (
-                "zoo:"
-                "cv/detection/yolov5-s/"
-                "pytorch/ultralytics/coco/pruned_quant-aggressive_94"
-            ),
-            True,
-            files_yolo.union({"recipe.md", "recipe_transfer_learn.md"}),
-        ),
-        (
-            "yolov5-x-coco-pruned70.4block_quantized",
-            False,
-            files_yolo.union({"recipe.md", "recipe_transfer_learn.md"}),
-        ),
-        (
-            "yolov5-n6-voc_coco-pruned55",
-            False,
-            files_yolo.union({"recipe.md"}),
-        ),
-        (
-            "resnet_v1-50-imagenet-channel30_pruned90_quantized",
-            False,
-            files_yolo.union({"recipe.md", "recipe_transfer_classification.md"}),
-        ),
+        # (
+        #     (
+        #         "zoo:"
+        #         "nlp/question_answering/distilbert-none/"
+        #         "pytorch/huggingface/squad/pruned80_quant-none-vnni"
+        #     ),
+        #     False,
+        #     files_nlp.union({"recipe.md"}),
+        # ),
+        # (
+        #     (
+        #         "zoo:"
+        #         "cv/detection/yolov5-s/"
+        #         "pytorch/ultralytics/coco/pruned_quant-aggressive_94"
+        #     ),
+        #     True,
+        #     files_yolo.union({"recipe.md", "recipe_transfer_learn.md"}),
+        # ),
+        # (
+        #     "yolov5-x-coco-pruned70.4block_quantized",
+        #     False,
+        #     files_yolo.union({"recipe.md", "recipe_transfer_learn.md"}),
+        # ),
+        # (
+        #     "yolov5-n6-voc_coco-pruned55",
+        #     False,
+        #     files_yolo.union({"recipe.md"}),
+        # ),
+        # (
+        #     "resnet_v1-50-imagenet-channel30_pruned90_quantized",
+        #     False,
+        #     files_yolo.union({"recipe.md", "recipe_transfer_classification.md"}),
+        # ),
     ],
     scope="function",
 )
@@ -184,10 +184,6 @@ class TestModel:
         temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
         model = Model(stub, temp_dir.name)
         model.download()
-        # since downloading the `deployment` file is
-        # disabled by default, we need to do it
-        # explicitly
-        model.deployment.download()
         self._add_mock_files(temp_dir.name, clone_sample_outputs=clone_sample_outputs)
         model = Model(temp_dir.name)
 

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -23,7 +23,6 @@ import numpy
 import pytest
 
 from sparsezoo import Model
-from sparsezoo.objects.directories import SelectDirectory
 
 
 files_ic = {
@@ -61,40 +60,40 @@ files_yolo = copy.copy(files_ic)
             ("recipe", "transfer_learn"),
             True,
         ),
-        # (
-        #     "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
-        #     "pruned-moderate",
-        #     ("checkpoint", "some_dummy_name"),
-        #     False,
-        # ),
-        # (
-        #     "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
-        #     "pruned-moderate",
-        #     ("deployment", "default"),
-        #     True,
-        # ),
-        # (
-        #     "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
-        #     "pruned-moderate",
-        #     ("checkpoint", "preqat"),
-        #     True,
-        # ),
-        # (
-        #     "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/"
-        #     "12layer_pruned80_quant-none-vnni",
-        #     ("checkpoint", "postqat"),
-        #     True,
-        # ),
-        # (
-        #     "biobert-base_cased-jnlpba_pubmed-pruned80.4block_quantized",
-        #     ("deployment", "default"),
-        #     True,
-        # ),
-        # (
-        #     "resnet_v1-50-imagenet-pruned95",
-        #     ("checkpoint", "preqat"),
-        #     True,
-        # ),
+        (
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+            "pruned-moderate",
+            ("checkpoint", "some_dummy_name"),
+            False,
+        ),
+        (
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+            "pruned-moderate",
+            ("deployment", "default"),
+            True,
+        ),
+        (
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/"
+            "pruned-moderate",
+            ("checkpoint", "preqat"),
+            True,
+        ),
+        (
+            "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/"
+            "12layer_pruned80_quant-none-vnni",
+            ("checkpoint", "postqat"),
+            True,
+        ),
+        (
+            "biobert-base_cased-jnlpba_pubmed-pruned80.4block_quantized",
+            ("deployment", "default"),
+            True,
+        ),
+        (
+            "resnet_v1-50-imagenet-pruned95",
+            ("checkpoint", "preqat"),
+            True,
+        ),
     ],
     scope="function",
 )
@@ -142,39 +141,39 @@ class TestSetupModel:
             True,
             files_ic.union({"recipe.md", "recipe_transfer_learn.md"}),
         ),
-        # (
-        #     (
-        #         "zoo:"
-        #         "nlp/question_answering/distilbert-none/"
-        #         "pytorch/huggingface/squad/pruned80_quant-none-vnni"
-        #     ),
-        #     False,
-        #     files_nlp.union({"recipe.md"}),
-        # ),
-        # (
-        #     (
-        #         "zoo:"
-        #         "cv/detection/yolov5-s/"
-        #         "pytorch/ultralytics/coco/pruned_quant-aggressive_94"
-        #     ),
-        #     True,
-        #     files_yolo.union({"recipe.md", "recipe_transfer_learn.md"}),
-        # ),
-        # (
-        #     "yolov5-x-coco-pruned70.4block_quantized",
-        #     False,
-        #     files_yolo.union({"recipe.md", "recipe_transfer_learn.md"}),
-        # ),
-        # (
-        #     "yolov5-n6-voc_coco-pruned55",
-        #     False,
-        #     files_yolo.union({"recipe.md"}),
-        # ),
-        # (
-        #     "resnet_v1-50-imagenet-channel30_pruned90_quantized",
-        #     False,
-        #     files_yolo.union({"recipe.md", "recipe_transfer_classification.md"}),
-        # ),
+        (
+            (
+                "zoo:"
+                "nlp/question_answering/distilbert-none/"
+                "pytorch/huggingface/squad/pruned80_quant-none-vnni"
+            ),
+            False,
+            files_nlp.union({"recipe.md"}),
+        ),
+        (
+            (
+                "zoo:"
+                "cv/detection/yolov5-s/"
+                "pytorch/ultralytics/coco/pruned_quant-aggressive_94"
+            ),
+            True,
+            files_yolo.union({"recipe.md", "recipe_transfer_learn.md"}),
+        ),
+        (
+            "yolov5-x-coco-pruned70.4block_quantized",
+            False,
+            files_yolo.union({"recipe.md", "recipe_transfer_learn.md"}),
+        ),
+        (
+            "yolov5-n6-voc_coco-pruned55",
+            False,
+            files_yolo.union({"recipe.md"}),
+        ),
+        (
+            "resnet_v1-50-imagenet-channel30_pruned90_quantized",
+            False,
+            files_yolo.union({"recipe.md", "recipe_transfer_classification.md"}),
+        ),
     ],
     scope="function",
 )
@@ -338,49 +337,6 @@ def test_model_gz_extraction_from_local_files(stub: str):
         "imagenet/pruned-moderate",
     ],
 )
-def test_model_deployment_directory(stub):
-    temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
-    expected_deployment_files = ["model.onnx"]
-
-    model = Model(stub, temp_dir.name)
-    assert model.deployment_tar.is_archive
-    # download and extract deployment tar
-    deployment_dir_path = model.deployment_directory_path
-
-    # deployment and deployment_tar should be point to the same files
-    assert deployment_dir_path == model.deployment_tar.path == model.deployment.path
-    # make sure that the model contains expected files
-    assert set(os.listdir(temp_dir.name)) == {"deployment.tar.gz", "deployment"}
-    assert (
-        os.listdir(os.path.join(temp_dir.name, "deployment"))
-        == expected_deployment_files
-    )
-
-    assert isinstance(model.deployment, SelectDirectory)
-    # TODO: this should be 1. However, the API is returning for `deployment` file type
-    # both `model.onnx` and `deployment/model.onnx`.
-    # This should probably be fixed on the API side
-    assert (
-        len(model.deployment.files) == 2
-    )  # should be == len(expected_deployment_files)
-
-    assert isinstance(model.deployment_tar, SelectDirectory)
-    assert len(model.deployment_tar.files) == len(expected_deployment_files)
-    assert not model.deployment_tar.is_archive
-
-    # test recreating the model from the local files
-    model = Model(temp_dir.name)
-
-    assert isinstance(model.deployment, SelectDirectory)
-    assert len(model.deployment.files) == len(expected_deployment_files)
-
-    assert isinstance(model.deployment_tar, SelectDirectory)
-    assert len(model.deployment_tar.files) == len(expected_deployment_files)
-    assert not model.deployment_tar.is_archive
-
-    shutil.rmtree(temp_dir.name)
-
-
 def _extraction_test_helper(model: Model):
     # download and extract model.onnx.tar.gz
     #  path should point to extracted model.onnx file

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -23,10 +23,12 @@ import numpy
 import pytest
 
 from sparsezoo import Model
+from sparsezoo.objects.directories import SelectDirectory
 
 
 files_ic = {
     "training",
+    "deployment.tar.gz",
     "deployment",
     "logs",
     "onnx",
@@ -182,6 +184,10 @@ class TestModel:
         temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
         model = Model(stub, temp_dir.name)
         model.download()
+        # since downloading the `deployment` file is
+        # disabled by default, we need to do it
+        # explicitly
+        model.deployment.download()
         self._add_mock_files(temp_dir.name, clone_sample_outputs=clone_sample_outputs)
         model = Model(temp_dir.name)
 
@@ -326,6 +332,56 @@ def test_model_gz_extraction_from_local_files(stub: str):
     source = temp_dir.name
     model_from_local_files = Model(source)
     _extraction_test_helper(model_from_local_files)
+    shutil.rmtree(temp_dir.name)
+
+
+@pytest.mark.parametrize(
+    "stub",
+    [
+        "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/"
+        "imagenet/pruned-moderate",
+    ],
+)
+def test_model_deployment_directory(stub):
+    temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+    expected_deployment_files = ["model.onnx"]
+
+    model = Model(stub, temp_dir.name)
+    assert model.deployment_tar.is_archive
+    # download and extract deployment tar
+    deployment_dir_path = model.deployment_directory_path
+
+    # deployment and deployment_tar should be point to the same files
+    assert deployment_dir_path == model.deployment_tar.path == model.deployment.path
+    # make sure that the model contains expected files
+    assert set(os.listdir(temp_dir.name)) == {"deployment.tar.gz", "deployment"}
+    assert (
+        os.listdir(os.path.join(temp_dir.name, "deployment"))
+        == expected_deployment_files
+    )
+
+    assert isinstance(model.deployment, SelectDirectory)
+    # TODO: this should be 1. However, the API is returning for `deployment` file type
+    # both `model.onnx` and `deployment/model.onnx`.
+    # This should probably be fixed on the API side
+    assert (
+        len(model.deployment.files) == 2
+    )  # should be == len(expected_deployment_files)
+
+    assert isinstance(model.deployment_tar, SelectDirectory)
+    assert len(model.deployment_tar.files) == len(expected_deployment_files)
+    assert not model.deployment_tar.is_archive
+
+    # test recreating the model from the local files
+    model = Model(temp_dir.name)
+
+    assert isinstance(model.deployment, SelectDirectory)
+    assert len(model.deployment.files) == len(expected_deployment_files)
+
+    assert isinstance(model.deployment_tar, SelectDirectory)
+    assert len(model.deployment_tar.files) == len(expected_deployment_files)
+    assert not model.deployment_tar.is_archive
+
     shutil.rmtree(temp_dir.name)
 
 

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -68,14 +68,14 @@ EXPECTED_YOLO_FILES = {
 @pytest.mark.parametrize(
     "stub, expected_files",
     [
-        # (
-        #     "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
-        #     EXPECTED_IC_FILES,
-        # ),
-        # (
-        #     "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni",  # noqa E501
-        #     EXPECTED_NLP_FILES,
-        # ),
+        (
+            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+            EXPECTED_IC_FILES,
+        ),
+        (
+            "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni",  # noqa E501
+            EXPECTED_NLP_FILES,
+        ),
         (
             "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94",  # noqa E501
             EXPECTED_YOLO_FILES,
@@ -172,7 +172,7 @@ class TestSetupModel:
             "recipe.md",
             "model.onnx",
             "model.onnx.tar.gz",
-            "sample-inputs.tar.gz",
+            "sample-inputs",
         }
         check_extraneous_files(expected_files, temp_dir, ignore_external_data)
 
@@ -180,7 +180,6 @@ class TestSetupModel:
         stub, temp_dir, download_dir, ignore_external_data = setup
         model = Model(stub, download_dir.name)
         model.download()
-        model.sample_inputs.unzip()
 
         training = model.training
         deployment = model.deployment

--- a/tests/sparsezoo/model/test_utils.py
+++ b/tests/sparsezoo/model/test_utils.py
@@ -68,14 +68,14 @@ EXPECTED_YOLO_FILES = {
 @pytest.mark.parametrize(
     "stub, expected_files",
     [
-        (
-            "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
-            EXPECTED_IC_FILES,
-        ),
-        (
-            "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni",  # noqa E501
-            EXPECTED_NLP_FILES,
-        ),
+        # (
+        #     "zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate",  # noqa E501
+        #     EXPECTED_IC_FILES,
+        # ),
+        # (
+        #     "zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni",  # noqa E501
+        #     EXPECTED_NLP_FILES,
+        # ),
         (
             "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94",  # noqa E501
             EXPECTED_YOLO_FILES,


### PR DESCRIPTION
## Feature Description

Now, any directory that can be downloaded as tar.gz and then unzipped is by default downloaded in such a manner. 
This does not prevent us from downloading single, "loose" files from the directory in question.

### Downloading the `deployment` directory
Note, that the deployment is downloaded as tar and then unzipped:

```python
stub = "zoo:mobilenet_v1-1.0-imagenet-pruned.4block_quantized"

model = Model(stub)
deployment_path = model.deployment.path
print(os.listdir(deployment_path))
print(os.listdir(model._path))
```

```bash
Downloading (…)ed/deployment.tar.gz: 100%|██████████| 4.48M/4.48M [00:00<00:00, 12.7MB/s]
['model.onnx']
['deployment', 'deployment.tar.gz']
```

### Downloading the whole model
Note, that the appropriate folders get downloaded as tars and then unzipped

```python
model = Model(stub)
print(os.listdir(model.path))
```

```bash
Downloading (…)d/training/model.pth: 100%|██████████| 32.6M/32.6M [00:02<00:00, 12.5MB/s]
Downloading (…)training-metric.yaml: 100%|██████████| 168/168 [00:00<00:00, 89.7kB/s]
Downloading (…)ed/deployment.tar.gz: 100%|██████████| 4.48M/4.48M [00:00<00:00, 12.0MB/s]
Downloading (…)ple-originals.tar.gz: 100%|██████████| 4.07M/4.07M [00:00<00:00, 9.58MB/s]
Downloading (…)sample-inputs.tar.gz: 100%|██████████| 3.31M/3.31M [00:00<00:00, 11.1MB/s]
Downloading (…)ample-outputs.tar.gz: 100%|██████████| 152k/152k [00:00<00:00, 4.29MB/s]
Downloading (…)sample-labels.tar.gz: 100%|██████████| 170k/170k [00:00<00:00, 3.43MB/s]
Downloading (…)k_quantized/model.md: 100%|██████████| 1.98k/1.98k [00:00<00:00, 1.19MB/s]
Downloading (…)ed/model.onnx.tar.gz: 100%|██████████| 4.48M/4.48M [00:00<00:00, 10.6MB/s]
['sample-inputs', 'sample-labels.tar.gz', 'deployment', 'sample-originals', 'sample-originals.tar.gz', 'deployment.tar.gz', 'model.md', 'sample-outputs.tar.gz', 'sample-inputs.tar.gz', 'model.onnx', 'sample-outputs', 'training', 'model.onnx.tar.gz', 'sample-labels']
```

### Downloading a single "loose" `deployment` file

```python
model = Model(stub)
deployment_onnx_file = model.deployment.get_file("model.onnx").path
print(os.listdir(os.path.dirname(deployment_onnx_file)))
print(os.listdir(model._path))
```

```bash
Downloading (…)eployment/model.onnx: 100%|██████████| 7.00M/7.00M [00:00<00:00, 11.4MB/s]
['model.onnx']
['deployment']
```


