### PR TITLE
`RegistryMixin` improved alias management

### DIFF
--- a/src/sparsezoo/utils/registry.py
+++ b/src/sparsezoo/utils/registry.py
@@ -225,8 +225,9 @@ def get_from_registry(
         module_path, value_name = name.split(":")
         retrieved_value = _import_and_get_value_from_module(module_path, value_name)
     else:
-        # look up name in registry
+        # look up name in alias registry
         name = _ALIAS_REGISTRY.get(name)
+        # look up name in registry
         retrieved_value = _REGISTRY[parent_class].get(name)
         if retrieved_value is None:
             raise KeyError(
@@ -293,6 +294,12 @@ def register_alias(name: str, alias: Union[str, List[str], None] = None):
     alias = _add_hyphen_underscores_variants(alias)
 
     for alias_name in alias:
+        if alias_name in _ALIAS_REGISTRY:
+            raise KeyError(
+                f"Attempting to register alias {alias_name} as {name} "
+                f"however {alias_name} has already been registered as "
+                f"{_ALIAS_REGISTRY[alias_name]}"
+            )
         _ALIAS_REGISTRY[alias_name] = name
 
 

--- a/src/sparsezoo/utils/registry.py
+++ b/src/sparsezoo/utils/registry.py
@@ -67,7 +67,7 @@ class RegistryMixin:
         pass
 
     # register with multiple aliases
-    @Dataset.register(name=["cifar-10-dataset", "cifar-100-dataset"])
+    @Dataset.register(alias=["cifar-10-dataset", "cifar_100_dataset"])
     class Cifar(Dataset):
         pass
 
@@ -77,6 +77,13 @@ class RegistryMixin:
     # load from custom file that implements a dataset
     mnist = Dataset.load_from_registry("/path/to/mnnist_dataset.py:MnistDataset")
     ```
+
+    Note, that any name or alias that is being registered, will be also recognized
+    when all hyphens are replaced with underscores and vice versa.
+    For example, if a class is registered:
+     - as "cifar-10-dataset", it will be also recognized as "cifar_10_dataset"
+     - as "cifar_10_dataset", it will be also recognized as "cifar-10-dataset"
+        etc.
     """
 
     # set to True in child class to add check that registered/retrieved values

--- a/src/sparsezoo/utils/registry.py
+++ b/src/sparsezoo/utils/registry.py
@@ -53,6 +53,17 @@ def standardize_lookup_name(name: str) -> str:
     return name.replace("_", "-").replace(" ", "-").lower()
 
 
+def standardize_alias_name(
+    name: Union[None, str, List[str]]
+) -> Union[None, str, List[str]]:
+    if name is None:
+        return None
+    elif isinstance(name, str):
+        return standardize_lookup_name(name)
+    else:  # isinstance(name, list)
+        return [standardize_lookup_name(n) for n in name]
+
+
 class RegistryMixin:
     """
     Universal registry to support registration and loading of child classes and plugins
@@ -210,6 +221,7 @@ def register(
         name = value.__name__
 
     name = standardize_lookup_name(name)
+    alias = standardize_alias_name(alias)
     register_alias(name=name, alias=alias, parent_class=parent_class)
 
     if require_subclass:

--- a/src/sparsezoo/utils/registry.py
+++ b/src/sparsezoo/utils/registry.py
@@ -198,7 +198,6 @@ def register(
     if name in _REGISTRY[parent_class]:
         # name already exists - raise error if two different values are attempting
         # to share the same name
-        name = _ALIAS_REGISTRY[name]
         registered_value = _REGISTRY[parent_class][name]
         if registered_value is not value:
             raise RuntimeError(
@@ -227,10 +226,8 @@ def get_from_registry(
         retrieved_value = _import_and_get_value_from_module(module_path, value_name)
     else:
         # look up name in registry
-
         name = _ALIAS_REGISTRY.get(name)
         retrieved_value = _REGISTRY[parent_class].get(name)
-
         if retrieved_value is None:
             raise KeyError(
                 f"Unable to find {name} registered under type {parent_class}.\n"

--- a/src/sparsezoo/utils/registry.py
+++ b/src/sparsezoo/utils/registry.py
@@ -44,13 +44,13 @@ def standardize_lookup_name(name: str) -> str:
 
     example:
     ```
-    standardize_lookup_name("foo_bar baz") == "foo-bar-baz"
+    standardize_lookup_name("Foo_bar baz") == "foo-bar-baz"
     ```
 
     :param name: name to standardize
     :return: standardized name
     """
-    return name.replace("_", "-").replace(" ", "-")
+    return name.replace("_", "-").replace(" ", "-").lower()
 
 
 class RegistryMixin:

--- a/tests/sparsezoo/utils/test_registry.py
+++ b/tests/sparsezoo/utils/test_registry.py
@@ -44,7 +44,7 @@ class TestRegistryFlowSingle:
         class Foo1(foo):
             pass
 
-        assert {"Foo1"} == set(foo.registered_names())
+        assert {"foo1"} == set(foo.registered_names())
         assert set() == set(foo.registered_aliases())
 
     def test_single_item_custom_name(self, foo):
@@ -68,7 +68,7 @@ class TestRegistryFlowSingle:
         class Foo1(foo):
             pass
 
-        assert {"Foo1"} == set(foo.registered_names())
+        assert {"foo1"} == set(foo.registered_names())
         assert {"name-3", "name_4"} == set(foo.registered_aliases())
 
     def test_key_error_on_duplicate_alias(self, foo):
@@ -144,11 +144,11 @@ class TestRegistryFlowMultiple:
         class Bar1(bar):
             pass
 
-        assert ["Foo1"] == foo.registered_names()
-        assert ["Bar1"] == bar.registered_names()
+        assert ["foo1"] == foo.registered_names()
+        assert ["bar1"] == bar.registered_names()
 
-        assert foo.get_value_from_registry("Foo1") is Foo1
-        assert bar.get_value_from_registry("Bar1") is Bar1
+        assert foo.get_value_from_registry("foo1") is Foo1
+        assert bar.get_value_from_registry("bar1") is Bar1
 
 
 def test_registry_requires_subclass():

--- a/tests/sparsezoo/utils/test_registry.py
+++ b/tests/sparsezoo/utils/test_registry.py
@@ -69,7 +69,7 @@ class TestRegistryFlowSingle:
             pass
 
         assert {"foo1"} == set(foo.registered_names())
-        assert {"name-3", "name_4"} == set(foo.registered_aliases())
+        assert {"name-3", "name-4"} == set(foo.registered_aliases())
 
     def test_key_error_on_duplicate_alias(self, foo):
         # once we register an object under one alias, we can't
@@ -111,7 +111,7 @@ class TestRegistryFlowSingle:
             pass
 
         assert {"name-2"} == set(foo.registered_names())
-        assert {"name-3", "name_4"} == set(foo.registered_aliases())
+        assert {"name-3", "name-4"} == set(foo.registered_aliases())
 
     def test_get_value_from_registry(self, foo):
         @foo.register(alias=["name-3"])


### PR DESCRIPTION
## Feature Description

Adds additional features the the `RegistryMixin`:
1. Separates concept of `name` and `alias`. Now, we can only have one name and several aliases
2. Registered names and aliases can be independently inspected using the appropriate methods
3. Registering and looking up names will be now robust wrt underscores and spaces (see the docstrings and tests)
4. Improves tests so their are more readable and extendable