### PR TITLE
More control over external data size

### DIFF
--- a/src/sparsezoo/utils/onnx/external_data.py
+++ b/src/sparsezoo/utils/onnx/external_data.py
@@ -92,7 +92,10 @@ def save_onnx(
     :return True if the model was saved with external data, False otherwise.
     """
     if external_data_file is not None:
-        _LOGGER.debug(f"Saving with external data: {external_data_file}")
+        _LOGGER.debug(
+            f"Saving with external data, with file chunks of maximum size "
+            f"{MAX_FILE_SIZE_EXTERNAL_DATA / 1e6} MB"
+        )
         _check_for_old_external_data(
             model_path=model_path, external_data_file=external_data_file
         )
@@ -103,13 +106,15 @@ def save_onnx(
             all_tensors_to_one_file=True,
             location=external_data_file,
         )
+        split_external_data(model_path, MAX_FILE_SIZE_EXTERNAL_DATA)
         return True
 
     if model.ByteSize() > MAX_FILE_SIZE_EXTERNAL_DATA:
         external_data_file = external_data_file or EXTERNAL_ONNX_DATA_NAME
         _LOGGER.warning(
             "The ONNX model is too large to be saved as a single protobuf. "
-            f"Saving with external data: {external_data_file}"
+            "Saving with external data, with file chunks of maximum size "
+            f"{MAX_FILE_SIZE_EXTERNAL_DATA / 1e6} MB"
         )
         _check_for_old_external_data(
             model_path=model_path, external_data_file=external_data_file

--- a/src/sparsezoo/utils/onnx/external_data.py
+++ b/src/sparsezoo/utils/onnx/external_data.py
@@ -39,6 +39,11 @@ __all__ = [
 
 EXTERNAL_ONNX_DATA_NAME = "model.data"
 
+# The maximum size of a single data file in megabytes
+# set to 400MB. This is roughly the size of
+# 25 million parameters (assuming fp16).
+MAX_FILE_SIZE_EXTERNAL_DATA = 4e8
+
 
 def onnx_includes_external_data(model: ModelProto) -> bool:
     """
@@ -100,7 +105,7 @@ def save_onnx(
         )
         return True
 
-    if model.ByteSize() > onnx.checker.MAXIMUM_PROTOBUF:
+    if model.ByteSize() > MAX_FILE_SIZE_EXTERNAL_DATA:
         external_data_file = external_data_file or EXTERNAL_ONNX_DATA_NAME
         _LOGGER.warning(
             "The ONNX model is too large to be saved as a single protobuf. "
@@ -116,6 +121,7 @@ def save_onnx(
             all_tensors_to_one_file=True,
             location=external_data_file,
         )
+        split_external_data(model_path, MAX_FILE_SIZE_EXTERNAL_DATA)
         return True
 
     onnx.save(model, model_path)

--- a/src/sparsezoo/utils/onnx/external_data.py
+++ b/src/sparsezoo/utils/onnx/external_data.py
@@ -39,10 +39,13 @@ __all__ = [
 
 EXTERNAL_ONNX_DATA_NAME = "model.data"
 
-# The maximum size of a single data file in megabytes
-# set to 400MB. This is roughly the size of
-# 25 million parameters (assuming fp16).
-MAX_FILE_SIZE_EXTERNAL_DATA = 4e8
+# DUMP_EXTERNAL_DATA_TRESHOLD is a limiting value
+# for the model saved with external data. If the model
+# is larger than this value, it will be saved with external data.
+# The threshold is expressed in bits and corresponds
+# set to 500MB. This is roughly the size of
+# 250 million parameters (assuming fp16).
+DUMP_EXTERNAL_DATA_THRESHOLD = 4e9
 
 
 def onnx_includes_external_data(model: ModelProto) -> bool:
@@ -71,6 +74,7 @@ def onnx_includes_external_data(model: ModelProto) -> bool:
 def save_onnx(
     model: ModelProto,
     model_path: str,
+    max_external_file_size: int = 16e9,
     external_data_file: Optional[str] = None,
 ) -> bool:
     """
@@ -89,12 +93,14 @@ def save_onnx(
         large to be saved as a single protobuf, and this argument is None,
         the external data file will be coerced to take the default name
         specified in the variable EXTERNAL_ONNX_DATA_NAME
+    :param max_external_file_size: The maximum file size in bytes of a single split
+        external data out file. Defaults to 16000000000 (16e9 = 16GB)
     :return True if the model was saved with external data, False otherwise.
     """
     if external_data_file is not None:
         _LOGGER.debug(
             f"Saving with external data, with file chunks of maximum size "
-            f"{MAX_FILE_SIZE_EXTERNAL_DATA / 1e6} MB"
+            f"{max_external_file_size / 1e9} GB"
         )
         _check_for_old_external_data(
             model_path=model_path, external_data_file=external_data_file
@@ -106,15 +112,15 @@ def save_onnx(
             all_tensors_to_one_file=True,
             location=external_data_file,
         )
-        split_external_data(model_path, MAX_FILE_SIZE_EXTERNAL_DATA)
+        split_external_data(model_path, max_file_size=max_external_file_size)
         return True
 
-    if model.ByteSize() > MAX_FILE_SIZE_EXTERNAL_DATA:
+    if model.ByteSize() > DUMP_EXTERNAL_DATA_THRESHOLD:
         external_data_file = external_data_file or EXTERNAL_ONNX_DATA_NAME
         _LOGGER.warning(
             "The ONNX model is too large to be saved as a single protobuf. "
             "Saving with external data, with file chunks of maximum size "
-            f"{MAX_FILE_SIZE_EXTERNAL_DATA / 1e6} MB"
+            f"{DUMP_EXTERNAL_DATA_THRESHOLD / 1e9} GB"
         )
         _check_for_old_external_data(
             model_path=model_path, external_data_file=external_data_file
@@ -126,7 +132,7 @@ def save_onnx(
             all_tensors_to_one_file=True,
             location=external_data_file,
         )
-        split_external_data(model_path, MAX_FILE_SIZE_EXTERNAL_DATA)
+        split_external_data(model_path, max_file_size=max_external_file_size)
         return True
 
     onnx.save(model, model_path)

--- a/src/sparsezoo/utils/onnx/external_data.py
+++ b/src/sparsezoo/utils/onnx/external_data.py
@@ -117,10 +117,10 @@ def save_onnx(
 
     if model.ByteSize() > DUMP_EXTERNAL_DATA_THRESHOLD:
         external_data_file = external_data_file or EXTERNAL_ONNX_DATA_NAME
-        _LOGGER.warning(
+        _LOGGER.debug(
             "The ONNX model is too large to be saved as a single protobuf. "
             "Saving with external data, with file chunks of maximum size "
-            f"{DUMP_EXTERNAL_DATA_THRESHOLD / 1e9} GB"
+            f"{max_external_file_size / 1e9} GB"
         )
         _check_for_old_external_data(
             model_path=model_path, external_data_file=external_data_file


### PR DESCRIPTION
As discussed recently:
- let's fold the splitting of big internal files into `onnx_save` 
- split the model.onnx into graph and constant tensors once the model.onnx is larger then DUMP_EXTERNAL_DATA_THRESHOLD (500MB)
- let's allow the user to control the size of created external tensor files 
 For usage see: https://github.com/neuralmagic/sparseml/pull/1983