### PR TITLE
add support for benchmark.yaml

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -181,6 +181,9 @@ class Model(Directory):
         self.benchmarks: File = self._file_from_files(
             files, display_name="benchmarks.yaml"
         )
+        self.benchmark: File = self._file_from_files(
+            files, display_name="benchmark.yaml"
+        )
         self.eval_results: File = self._file_from_files(files, display_name="eval.yaml")
 
         # plaintext validation metrics optionally parsed from a zoo stub
@@ -241,6 +244,7 @@ class Model(Directory):
             "onnx_model": self.onnx_model,
             "analysis": self.analysis,
             "benchmarks": self.benchmarks,
+            "benchmark": self.benchmark,
             "eval_results": self.eval_results,
         }
 

--- a/src/sparsezoo/model/utils.py
+++ b/src/sparsezoo/model/utils.py
@@ -58,6 +58,7 @@ ALLOWED_FILE_TYPES = {
     "benchmarking",
     "outputs",
     "onnx_gz",
+    "benchmark",
 }
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/sparsezoo/model/test_model.py
+++ b/tests/sparsezoo/model/test_model.py
@@ -42,6 +42,7 @@ files_ic = {
     "sample-labels",
     "sample-outputs",
     "benchmarks.yaml",
+    "benchmark.yaml",
     "eval.yaml",
     "analysis.yaml",
     "model.md",


### PR DESCRIPTION
recent zoo models use `benchmark.yaml` instead of `benchmarks.yaml`. adding this additional pathway so `benchmark.yaml` is downloaded in the bulk model download

example:
```python
from sparsezoo import Model

stub = "zoo:llama2-7b-ultrachat200k_llama2_pretrain-base"

model = Model(stub)
model.benchmark.path
```