### PR TITLE
Fix misleading docstring in `RegistryMixin`

### DIFF
--- a/src/sparsezoo/utils/registry.py
+++ b/src/sparsezoo/utils/registry.py
@@ -104,7 +104,6 @@ class RegistryMixin:
     @Dataset.register(alias=["cifar-10-dataset", "cifar_100_dataset"])
     class Cifar(Dataset):
         pass
-    Note: aliases will NOT be standardized for lookup in the registry.
 
     # load as "cifar-dataset"
     cifar = Dataset.load_from_registry("cifar-dataset")

--- a/tests/sparsezoo/utils/test_registry.py
+++ b/tests/sparsezoo/utils/test_registry.py
@@ -71,6 +71,16 @@ class TestRegistryFlowSingle:
         assert {"foo1"} == set(foo.registered_names())
         assert {"name-3", "name-4"} == set(foo.registered_aliases())
 
+    def test_alias_is_standardized(self, foo):
+        alias = "Name_3"
+        expected_standardized_alias = "name-3"
+
+        @foo.register(alias=[alias])
+        class Foo1(foo):
+            pass
+
+        assert {expected_standardized_alias} == set(foo.registered_aliases())
+
     def test_key_error_on_duplicate_alias(self, foo):
         # once we register an object under one alias, we can't
         # register it under the same alias once again


### PR DESCRIPTION
This PR fixes a misleading docstring in `RegistryMixin`
Also adds a test to check behavior

```bash
$ pytest -v tests/sparsezoo/utils/test_registry.py::TestRegistryFlowSingle::test_alias_is_standardized       
=============================================== test session starts ================================================
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0 -- /home/rahul/venvs/.base_venv/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/rahul/projects/sparsezoo
plugins: flaky-3.7.0, anyio-4.2.0, mock-3.12.0, hydra-core-1.3.2
collected 1 item                                                                                                   

tests/sparsezoo/utils/test_registry.py::TestRegistryFlowSingle::test_alias_is_standardized PASSED  
```