### PR TITLE
[Fix] Allow for processing `Path` in the sparsezoo analysis

### DIFF
--- a/src/sparsezoo/analyze/analysis.py
+++ b/src/sparsezoo/analyze/analysis.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import numpy
-import onnx
 import yaml
 from onnx import ModelProto, NodeProto
 from pydantic import BaseModel, Field, PositiveFloat, PositiveInt
@@ -68,6 +67,7 @@ from sparsezoo.utils import (
     is_parameterized_prunable_layer,
     is_quantized_layer,
     is_sparse_layer,
+    load_model,
 )
 
 
@@ -914,7 +914,7 @@ class ModelAnalysis(YAMLSerializableBaseModel):
             model_onnx = onnx_file_path
             model_name = ""
         else:
-            model_onnx = onnx.load(onnx_file_path)
+            model_onnx = load_model(onnx_file_path)
             model_name = str(onnx_file_path)
 
         model_graph = ONNXGraph(model_onnx)

--- a/src/sparsezoo/utils/onnx/external_data.py
+++ b/src/sparsezoo/utils/onnx/external_data.py
@@ -174,7 +174,7 @@ def validate_onnx(model: Union[str, ModelProto]):
         raise ValueError(f"Invalid onnx model: {err}")
 
 
-def load_model(model: Union[str, ModelProto]) -> ModelProto:
+def load_model(model: Union[str, ModelProto, Path]) -> ModelProto:
     """
     Load an ONNX model from an onnx model file path. If a ModelProto
     is given, then it is returned.
@@ -185,7 +185,7 @@ def load_model(model: Union[str, ModelProto]) -> ModelProto:
     if isinstance(model, ModelProto):
         return model
 
-    if isinstance(model, str):
+    if isinstance(model, (Path, str)):
         return onnx.load(clean_path(model))
 
     raise ValueError(f"unknown type given for model: {type(model)}")


### PR DESCRIPTION
`onnx.load()` has very limited support for loading models from the `Path` objects, especially when loading involves properly searching for external data. This causes the issue: https://app.asana.com/0/1206109050183159/1206486977947981/f - onnx tries to look for external data in the cwd and not in the directory where `model.onnx` is.

The solution is to refrain from using `onnx.load(...)` in favor of using our internal helper func `load_model`. That is slightly enhanced version of the func, that also works with `Path` objects.

Now:

```bash
deepsparse.analyze /home/damian/.cache/sparsezoo/neuralmagic/codellama-7b-evolcodealpaca_codellama_pretrain-pruned60_quantized/deployment
```

Does not fail on model loading:

```bash
2024-02-01 15:51:49 __main__     INFO     Starting Analysis ...
INFO:__main__:Starting Analysis ...
INFO:root:Loading `model.onnx` from deployment directory /home/damian/.cache/sparsezoo/neuralmagic/codellama-7b-evolcodealpaca_codellama_pretrain-pruned60_quantized/deployment
EP Error narrowing_error when using ['CPUExecutionProvider']
Falling back to ['CPUExecutionProvider'] and retrying.
WARNING:sparsezoo.utils.node_inference:Extracting shapes using ONNX Runtime session failed: narrowing_error
WARNING:sparsezoo.utils.node_inference:Falling back to ONNX shape_inference
...
```

Note: it fails later on, but for that we have a separate ticket 


