### PR TITLE
Fix `model.download()` returning False for downloaded directory

### DIFF
--- a/src/sparsezoo/model/model.py
+++ b/src/sparsezoo/model/model.py
@@ -703,23 +703,23 @@ class Model(Directory):
                 )
             ):
                 file.download(destination_path=directory_path)
-                return True
+                validations = True
             else:
                 _LOGGER.warning(
                     f"Failed to download file {file.name}. The url of the file is None."
                 )
-                return False
+                validations = False
 
         elif isinstance(file, Recipes):
-            validations = (
+            validations = all(
                 self._download(_file, directory_path) for _file in file.recipes
             )
 
         else:
-            validations = (
+            validations = all(
                 self._download(_file, directory_path) for _file in file.values()
             )
-            return all(validations)
+        return validations
 
     def _sample_outputs_list_to_dict(
         self,


### PR DESCRIPTION
# Summary
- For this ticket: https://app.asana.com/0/1206109050183159/1206405270522272/f
- Previously, we weren't returning anything when anything of type `Recipe` was passed to the  `_download()` function
- Update to make sure all paths return a boolean 
# Testing 

```python
from sparsezoo import Model 
m =  Model("zoo:yolov5-n-coco-pruned40_quantized")
dr = m.download()
print(dr)
```

# Output:
```bash
Downloading (…)ed/training/model.pt: 100%|███████████████████████████████████████████████████████████| 7.80M/7.80M [00:00<00:00, 83.0MB/s]
Downloading (…)ining/validation.txt: 100%|███████████████████████████████████████████████████████████| 28.9k/28.9k [00:00<00:00, 26.6MB/s]
Downloading (…)oint_preqat/model.pt: 100%|███████████████████████████████████████████████████████████| 3.71M/3.71M [00:00<00:00, 52.6MB/s]
Downloading (…)ed/deployment.tar.gz: 100%|███████████████████████████████████████████████████████████| 1.09M/1.09M [00:00<00:00, 27.6MB/s]
Downloading (…)sample-inputs.tar.gz: 100%|███████████████████████████████████████████████████████████| 19.5M/19.5M [00:00<00:00, 97.7MB/s]
Downloading (…)ample-outputs.tar.gz: 100%|█████████████████████████████████████████████████████████████| 151M/151M [00:01<00:00, 97.0MB/s]
Downloading (…)0_quantized/model.md: 100%|███████████████████████████████████████████████████████████| 1.15k/1.15k [00:00<00:00, 2.01MB/s]
Downloading (…)pe_transfer_learn.md: 100%|███████████████████████████████████████████████████████████| 2.44k/2.44k [00:00<00:00, 5.62MB/s]
Downloading (…)_quantized/recipe.md: 100%|███████████████████████████████████████████████████████████| 4.99k/4.99k [00:00<00:00, 10.1MB/s]
Downloading (…)ed/model.onnx.tar.gz: 100%|███████████████████████████████████████████████████████████| 1.09M/1.09M [00:00<00:00, 25.3MB/s]
True
```