### PR TITLE
Download deployment dir for llms

### DIFF
--- a/src/sparsezoo/analyze/analysis.py
+++ b/src/sparsezoo/analyze/analysis.py
@@ -1305,6 +1305,7 @@ class ModelAnalysis(YAMLSerializableBaseModel):
             result = ModelAnalysis.from_onnx(Path(file_path) / "model.onnx")
 
         elif file_path.startswith("zoo:"):
+            Model(file_path).deployment.download()
             result = ModelAnalysis.from_onnx(
                 Model(file_path).deployment.get_file("model.onnx").path
             )


### PR DESCRIPTION
Fixes a bug for ModelAnalysis class, when using LLMs with external data files, using just model.onnx to load the model would fail

Fix is to download the deployment directory with external data files first and then load the model