### PR TITLE
[Feature] Add Channel Wise Quantization Support

### DIFF
--- a/src/sparsezoo/analyze/analysis.py
+++ b/src/sparsezoo/analyze/analysis.py
@@ -304,9 +304,12 @@ class NodeAnalysis(YAMLSerializableBaseModel):
     )
     sparse_node: bool = Field(description="Does the node have sparse weights")
     quantized_node: bool = Field(description="Does the node have quantized weights")
-    zero_point: int = Field(
+    zero_point: Union[int, numpy.ndarray] = Field(
         description="Node zero point for quantization, default zero"
     )
+
+    class Config:
+        arbitrary_types_allowed = True
 
     @classmethod
     def from_node(

--- a/src/sparsezoo/utils/calculate_ops.py
+++ b/src/sparsezoo/utils/calculate_ops.py
@@ -195,10 +195,23 @@ def _get_gemm_dense_sparse_ops(
     :param is_four_block_sparse: true if the weight is four block sparse
     :return: number of dense and sparse operations performed
     """
-    if is_four_block_sparse:
-        weight_blocks = group_four_block(weight, pad_value=zero_point)
-        num_zeros_per_block = numpy.count_nonzero(weight_blocks == zero_point, axis=1)
+    is_channel_wise_quantized = isinstance(zero_point, numpy.ndarray)
+    if is_channel_wise_quantized:
+        # Broadcast zero_point per channel
+        zero_point = numpy.broadcast_to(zero_point, weight.shape)
 
+    if is_four_block_sparse:
+        weight_blocks = group_four_block(weight)
+        if is_channel_wise_quantized:
+            # Group zero_point in the same way as weight
+            zero_point_blocks = group_four_block(zero_point)
+            num_zeros_per_block = numpy.count_nonzero(
+                weight_blocks == zero_point_blocks, axis=1
+            )
+        else:
+            num_zeros_per_block = numpy.count_nonzero(
+                weight_blocks == zero_point, axis=1
+            )
         num_zero_blocks = numpy.count_nonzero(num_zeros_per_block == 4, axis=0)
         num_non_zero_blocks = numpy.count_nonzero(num_zeros_per_block != 4, axis=0)
 


### PR DESCRIPTION
This PR adds Channel Wise Quantization Support to `deepsparse.analyze` API and `ModelAnalysis class`

Before this PR:
```bash
deepsparse.analyze /network/alexandre/tyler/single_layer/deployment/model.onnx
  File "/home/ubuntu/venv/bin/deepsparse.analyze", line 8, in <module>
    sys.exit(main())
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/analyze/cli.py", line 98, in wrap_common_options
    return command(*args, **kwargs)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/analyze/cli.py", line 152, in wrap_with_performance_options
    return command(*args, **kwargs)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/deepsparse/analyze.py", line 77, in main
    analysis = ModelAnalysis.create(model_path)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/analyze/analysis.py", line 1308, in create
    result = ModelAnalysis.from_onnx(
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/analyze/analysis.py", line 922, in from_onnx
    node_analyses = cls.analyze_nodes(model_graph)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/analyze/analysis.py", line 1371, in analyze_nodes
    node_analysis = NodeAnalysis.from_node(
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/analyze/analysis.py", line 365, in from_node
    sparse_node = is_sparse_layer(model_graph, node)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/utils/onnx/analysis.py", line 257, in is_sparse_layer
    return get_node_sparsity(model_graph, node) > 0
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/utils/onnx/analysis.py", line 318, in get_node_sparsity
    num_zeros, weight_size = get_node_num_zeros_and_size(model_graph, node)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/utils/onnx/analysis.py", line 148, in get_node_num_zeros_and_size
    zero_point = get_zero_point(model_graph, node)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/sparsezoo/utils/onnx/analysis.py", line 244, in get_zero_point
    raise NotImplementedError("Channel-wise zero points are not supported")
NotImplementedError: Channel-wise zero points are not supported
```

After This PR (command runs successfully):

```bash
2024-02-12 09:00:04 deepsparse.analyze INFO     Starting Analysis ...
INFO:deepsparse.analyze:Starting Analysis ...
2024-02-12 09:00:40 deepsparse.analyze INFO     Analysis complete, collating results...
INFO:deepsparse.analyze:Analysis complete, collating results...
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.7.0.20240104 COMMUNITY | (86c38139) (release) (optimized) (system=avx512, binary=avx512)
[7f3c2eff4740 >WARN<  operator() ./src/include/wand/utility/warnings.hpp:14] Generating emulated code for quantized (INT8) operations since no VNNI instructions were detected. Set NM_FAST_VNNI_EMULATION=1 to increase performance at the expense of accuracy.
Node Timings for Benchmark # 1:
 NODE_NAME                      AVG_RUNTIME                    
 /model/layers.0/input_layernor 2.10                           
 m/ReduceMean                                                  
 /model/layers.0/input_layernor 3.89                           
 m/Mul                                                         
 /model/layers.0/self_attn/v_pr 183.68                         
 oj/module/MatMul_quant                                        
 /model/layers.0/self_attn/k_pr 182.47                         
 oj/module/MatMul_quant                                        
 /model/layers.0/self_attn/q_pr 181.16                         
 oj/module/MatMul_quant                                        
 /model/layers.0/self_attn/attn 125.34                         
 _weights_matmul/MatMul_quant                                  
 /model/Sub                     5.61                           
 /model/Add_1                   3.01                           
 /model/layers.0/self_attn/attn 157.15                         
 _output_matmul/MatMul_quant                                   
 /model/layers.0/self_attn/o_pr 186.67                         
 oj/module/MatMul_quant                                        
 /model/layers.0/mlp/up_proj/mo 565.44                         
 dule/MatMul_quant                                             
 /model/layers.0/mlp/gate_proj/ 567.57                         
 module/MatMul_quant                                           
 /model/layers.0/mlp/Mul        8.28                           
 /model/layers.0/mlp/down_proj/ 506.74                         
 module/MatMul_quant                                           
 /lm_head/module/MatMul_quant   25.92                          

Params:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE                           
 /home/rahul/models/llama-      29.77                          100.00                         464519168                      2609854493                     
 single-layer-channel-                                                                                                                                      
 quant/deployment/model.onnx                                                                                                                                

Ops:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE                           
 /home/rahul/models/llama-      29.77                          100.00                         464519374                      2609859089                     
 single-layer-channel-                                                                                                                                      
 quant/deployment/model.onnx                                                                                                                                

Overall:
 MODEL                          LATENCY                        THROUGHPUT                     SUPPORTED_GRAPH                SPARSITY                       QUANTIZED                      
 /home/rahul/models/llama-      2895.26                        0.35                           1.00                           29.77                          100.00                         
 single-layer-channel-                                                                                                                                                                     
 quant/deployment/model.onnx 
```

Can Also be tested with Sparsezoo using the following snippet:
```python
from sparsezoo.analyze import ModelAnalysis

model_path ="/network/alexandre/tyler/single_layer/deployment/model.onnx"
analysis = ModelAnalysis.create(model_path)
my_yaml = analysis.yaml()
print(my_yaml)
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206459509992243