### PR TITLE
[sparsezoo.analyze] Only save external data if the model has it

### DIFF
--- a/src/sparsezoo/utils/node_inference.py
+++ b/src/sparsezoo/utils/node_inference.py
@@ -86,10 +86,17 @@ def extract_nodes_shapes_and_dtypes_ort(
     sess_options = onnxruntime.SessionOptions()
     sess_options.log_severity_level = 3
 
+    # figure out if the current model has external data
+    has_external_data = False
+    for initializer in model.graph.initializer:
+        if initializer.HasField("data_location") and initializer.data_location == 1:
+            has_external_data = True
+            break
+
     if path:
         parent_dir = Path(path).parent.absolute()
         new_path = parent_dir / "model_new.onnx"
-        onnx.save(model_copy, new_path, save_as_external_data=True)
+        onnx.save(model_copy, new_path, save_as_external_data=has_external_data)
         sess = onnxruntime.InferenceSession(
             new_path, sess_options, providers=onnxruntime.get_available_providers()
         )


### PR DESCRIPTION
# Summary
- For this ticket: https://app.asana.com/0/1206109050183159/1206566521901608/f
- To start the session, the previous PR updated the function such that a new model would be saved post modification 
- When saving this modified model, `save_as_external_data` was always set to True. For models which do not have external data, this would create new external data files and save them to the current running directory. This would cause the inference session to fail due to the location
- Update the function to first check if the model has external data and only set `save_as_external_data` to be True if it does

# Testing
- Tested the failing models originally described in the ticket
- Tested with llama models (ultrachat, pretrain)