### PR TITLE
fix bug if the value is a dict

### DIFF
--- a/src/sparsezoo/api/utils.py
+++ b/src/sparsezoo/api/utils.py
@@ -42,11 +42,12 @@ def map_keys(
     """
     mapped_dict = {}
     for key, value in dictionary.items():
-        if isinstance(value, List) or isinstance(value, Dict):
-            value_type = type(value)
-            mapped_dict[mapper(key)] = value_type(
+        if isinstance(value, List):
+            mapped_dict[mapper(key)] = [
                 map_keys(dictionary=sub_dict, mapper=mapper) for sub_dict in value
-            )
+            ]
+        elif isinstance(value, Dict):
+            mapped_dict[mapper(key)] = dict(map_keys(dictionary=value, mapper=mapper))
         else:
             mapped_dict[mapper(key)] = value
 

--- a/tests/sparsezoo/api/test_graphql.py
+++ b/tests/sparsezoo/api/test_graphql.py
@@ -121,6 +121,11 @@ class TestGraphQLAPI(GraphQLAPI):
             },
             "fields": None,
         },
+        {
+            "operation_body": "models",
+            "arguments": {"stub": "zoo:mobilenet_v2-1.0-imagenet-base"},
+            "fields": {"analysis": {"analysisId": None}},
+        },
     ],
 )
 def test_graphql_api_response(query_args: Dict[str, Any]):

--- a/tests/sparsezoo/api/test_query_parser.py
+++ b/tests/sparsezoo/api/test_query_parser.py
@@ -172,6 +172,18 @@ from sparsezoo import QueryParser
                 ),
             },
         ),
+        (
+            {
+                "operation_body": "models",
+                "arguments": {"stub": "zoo:mobilenet_v2-1.0-imagenet-base"},
+                "fields": {"analysis": {"analysisId": None}},
+            },
+            {
+                "operation_body": "models",
+                "arguments": '(stub: "zoo:mobilenet_v2-1.0-imagenet-base",)',
+                "fields": "analysis { analysisId } ",
+            },
+        ),
     ],
 )
 def test_query_parser(


### PR DESCRIPTION
Bug fix. Bug fix example added to tests

```bash

>>> from sparsezoo.api import GraphQLAPI
>>> q = GraphQLAPI()
>>> q.fetch(operation_body="models",
...            arguments={"stub": "zoo:mobilenet_v2-1.0-imagenet-base"},
...            fields={"training_results": {"dataset_name": None}}
... )
[{'training_results': [{'dataset_name': 'imagenet'}]}]
>>> q.fetch(operation_body="models",
...            arguments={"stub": "zoo:mobilenet_v2-1.0-imagenet-base"},
...            fields={"analysis": {"analysisId": None}}
... )
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/derek/pyvenv/v170d31012/lib/python3.10/site-packages/sparsezoo/api/graphql.py", line 54, in fetch
```

