### PR TITLE
[BugFix] Adds a `numpy_array_representer` to yaml

### DIFF
--- a/src/sparsezoo/analyze/analysis.py
+++ b/src/sparsezoo/analyze/analysis.py
@@ -30,6 +30,7 @@ from onnx import ModelProto, NodeProto
 from pydantic import BaseModel, Field, PositiveFloat, PositiveInt
 
 from sparsezoo import Model
+from sparsezoo.analyze.utils.helpers import numpy_array_representer
 from sparsezoo.analyze.utils.models import (
     DenseSparseOps,
     Entry,
@@ -92,6 +93,9 @@ TARGETED_LINEAR_OP_TYPES = {
     "QLinearMatMul",
     "Gemm",
 }
+
+# add numpy array representer to yaml
+yaml.add_representer(numpy.ndarray, numpy_array_representer)
 
 
 class YAMLSerializableBaseModel(BaseModel):

--- a/src/sparsezoo/analyze/utils/helpers.py
+++ b/src/sparsezoo/analyze/utils/helpers.py
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
 
-from .helpers import *
+import numpy
+import yaml
+
+
+__all__ = [
+    "numpy_array_representer",
+]
+
+
+def numpy_array_representer(dumper: yaml.Dumper, data: numpy.ndarray):
+    """
+    A representer for numpy arrays to be used with pyyaml
+    """
+    return dumper.represent_sequence("tag:yaml.org,2002:seq", data.tolist())


### PR DESCRIPTION
This PR adds numpy serialization support for all our Pydantic BaseModel(s) that are yaml_serializable

Test Code:
```python
from sparsezoo.analyze import ModelAnalysis
import yaml

def save_model_analysis(model_path, save_path):
    analysis = ModelAnalysis.create(model_path)
    analysis.yaml(file_path=save_path)

def load_model_analysis(save_path):
    with open(save_path, 'r') as file:
       return yaml.safe_load(file)


if __name__ == "__main__":
    model_path ="/network/alexandre/tyler/single_layer/deployment/model.onnx"
    save_path = "test-analysis.yaml"
    save_model_analysis(model_path, save_path)
    loaded_yaml = load_model_analysis(save_path)

```

The `test-analysis.yaml` file has been attached with this description (I had to change the name to test-analysis.log cause GitHub doesn't support yaml file upload in PR description)

[test-analysis.log](https://github.com/neuralmagic/sparsezoo/files/14301978/test-analysis.log)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206604928587640