### PR TITLE
Download iso chunk folder

### DIFF
--- a/src/sparsezoo/utils/download.py
+++ b/src/sparsezoo/utils/download.py
@@ -93,13 +93,24 @@ class Downloader:
         self.chunk_bytes = chunk_bytes
         self.job_queues = Queue()
         self._lock = threading.Lock()
-        self.chunk_folder = self.get_parent_chunk_folder(download_path)
+        self.chunk_download_path = self.get_chunk_download_path(download_path)
 
-    def get_parent_chunk_folder(self, path: str) -> str:
-        """Get the name of the file that is used as folder inside chunks"""
-        path = path.split(os.path.sep)[-1]
-        path = path.replace(".", "_")
-        return path
+    def get_chunk_download_path(self, path: str) -> str:
+        """Get the path where chunks will be downloaded"""
+
+        # make the folder name from the model name and file to be downloaded
+        stub = path.split(os.path.sep)[-3]
+        path = "_".join(path.split(os.path.sep)[-2:])
+        file_name_as_folder = path.replace(".", "_")
+
+        # save the chunks on a different folder than the root model folder
+        return os.path.join(
+            os.path.abspath(
+                os.path.expanduser("~/.cache/sparsezoo/neuralmagic/chunks")
+            ),
+            stub,
+            file_name_as_folder,
+        )
 
     def is_range_header_supported(self) -> bool:
         """Check if chunck download is supported"""
@@ -171,8 +182,10 @@ class Downloader:
             bytes_range = f"bytes={start_byte}-{end_byte}"
 
             func_kwargs = {
-                "download_path": self.get_chunk_file_path(
-                    os.path.join(self.chunk_folder, f"{job_id:05d}_{bytes_range}")
+                "download_path": (
+                    os.path.join(
+                        self.chunk_download_path, f"{job_id:05d}_{bytes_range}"
+                    )
                 ),
                 "headers": {
                     "Range": bytes_range,
@@ -376,12 +389,10 @@ class Downloader:
         :param progress_bar: tqdm object showing the progress of combining chunks
 
         """
-        parent_directory = os.path.dirname(download_path)
-        chunk_directory = os.path.join(parent_directory, "chunks", self.chunk_folder)
-        _LOGGER.debug("Combing and deleting ", chunk_directory)
+        _LOGGER.debug("Combing and deleting ", self.chunk_download_path)
 
         pattern = re.compile(r"\d+_bytes=")
-        files = os.listdir(chunk_directory)
+        files = os.listdir(self.chunk_download_path)
 
         chunk_files = [chunk_file for chunk_file in files if pattern.match(chunk_file)]
 
@@ -390,13 +401,13 @@ class Downloader:
         create_parent_dirs(self.download_path)
         with open(self.download_path, "wb") as combined_file:
             for file_path in sorted_chunk_files:
-                chunk_path = os.path.join(chunk_directory, file_path)
+                chunk_path = os.path.join(self.chunk_download_path, file_path)
                 with open(chunk_path, "rb") as infile:
                     data = infile.read()
                     combined_file.write(data)
                     progress_bar.update(len(data))
 
-        shutil.rmtree(chunk_directory)
+        shutil.rmtree(self.chunk_download_path)
 
     def get_chunk_file_path(self, file_range: str) -> str:
         """

--- a/src/sparsezoo/utils/download.py
+++ b/src/sparsezoo/utils/download.py
@@ -107,6 +107,9 @@ class Downloader:
         # save the chunks on a different folder than the root model folder
         return os.path.join(
             str(Path.home()),
+            ".cache",
+            "sparsezoo",
+            "neuralmagic",
             "chunks",
             stub,
             file_name_as_folder,

--- a/src/sparsezoo/utils/download.py
+++ b/src/sparsezoo/utils/download.py
@@ -22,6 +22,7 @@ import re
 import shutil
 import threading
 from dataclasses import dataclass, field
+from pathlib import Path
 from queue import Queue
 from typing import Any, Callable, Dict, Optional
 
@@ -105,9 +106,8 @@ class Downloader:
 
         # save the chunks on a different folder than the root model folder
         return os.path.join(
-            os.path.abspath(
-                os.path.expanduser("~/.cache/sparsezoo/neuralmagic/chunks")
-            ),
+            str(Path.home()),
+            "chunks",
             stub,
             file_name_as_folder,
         )

--- a/src/sparsezoo/utils/onnx/external_data.py
+++ b/src/sparsezoo/utils/onnx/external_data.py
@@ -76,6 +76,7 @@ def save_onnx(
     model_path: str,
     max_external_file_size: int = 16e9,
     external_data_file: Optional[str] = None,
+    do_split_external_data: bool = True,
 ) -> bool:
     """
     Save model to the given path.
@@ -95,6 +96,8 @@ def save_onnx(
         specified in the variable EXTERNAL_ONNX_DATA_NAME
     :param max_external_file_size: The maximum file size in bytes of a single split
         external data out file. Defaults to 16000000000 (16e9 = 16GB)
+    :param do_split_external_data: True to split external data file into chunks of max
+    size max_external_file_size, false otherwise
     :return True if the model was saved with external data, False otherwise.
     """
     if external_data_file is not None:
@@ -112,7 +115,8 @@ def save_onnx(
             all_tensors_to_one_file=True,
             location=external_data_file,
         )
-        split_external_data(model_path, max_file_size=max_external_file_size)
+        if do_split_external_data:
+            split_external_data(model_path, max_file_size=max_external_file_size)
         return True
 
     if model.ByteSize() > DUMP_EXTERNAL_DATA_THRESHOLD:
@@ -132,7 +136,8 @@ def save_onnx(
             all_tensors_to_one_file=True,
             location=external_data_file,
         )
-        split_external_data(model_path, max_file_size=max_external_file_size)
+        if do_split_external_data:
+            split_external_data(model_path, max_file_size=max_external_file_size)
         return True
 
     onnx.save(model, model_path)
@@ -247,6 +252,9 @@ def split_external_data(
             f"{external_data_file_path} not found. {model_path} must have external "
             "data written to a single file in the same directory"
         )
+    if os.path.getsize(external_data_file_path) <= max_file_size:
+        # return immediately if file is small enough to not split
+        return
 
     # UPDATE: external data info of graph tensors so they point to the new split out
     # files with updated offsets
@@ -299,14 +307,6 @@ def split_external_data(
 
     # WRITE - ONNX model with updated tensor external data info
     onnx.save(model, model_path)
-
-    # RENAME - if as a result of splitting we end up with a single file, rename it to
-    # the original external data file name
-    if current_external_data_file_number == 1:
-        os.rename(
-            os.path.join(base_dir, updated_file_name),
-            os.path.join(base_dir, external_data_file),
-        )
 
 
 def _write_external_data_file_from_base_bytes(


### PR DESCRIPTION
Previous commit fails bc the chunks are saved in root model folder. 
Tests checks the expected files, where chunks are not included. 

Before these commits, chunk folder is deleted each run so it passed. Now if multiple downloading is running, then delete of a folder will have directory to write to

Chunks are now saved in `~/.cache/sparsezoo/neuralmagic/chunks/{stub}/{training_or_deployment_or_folder_name}/{model_data}/chunk1`

Combined chunks are saved in 
Chunks are now saved in `~/.cache/sparsezoo/neuralmagic/{stub}/training/model.data`
