### PR TITLE
Add build workflows for dev, nightly, and release wheels

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
-      - 'release/**'
+      - 'release/[0-9]+.[0-9]+'
   push:
     branches:
       - main
@@ -26,7 +26,7 @@ concurrency:
 # missing release tag workflow/needs to be added in
 env:
   INTERNAL: ${{ github.event_name != 'schedule' && github.event_name != 'release'}}
-  RELEASE: ${{ github.event_name =='release' || (github.base_ref == 'release/**' && github.event_name == 'pull_request')}}
+  RELEASE: ${{ github.event_name =='release' || (startsWith(github.base_ref, 'release/') && github.event_name == 'pull_request')}}
   DEV: ${{ github.base_ref == 'main' && github.event_name == 'pull_request'}}
   NAME: ${{ github.event.number }} 
 

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -45,14 +45,14 @@ jobs:
           aws-region: us-east-1 
       - name: Build PyPi Wheel
         id: build-wheel
-        uses: neuralmagic/nm-actions/actions/pypi_build@pypi-actions
+        uses: neuralmagic/nm-actions/actions/pypi_build
         with:
           dev: $DEV
           release: $RELEASE
           name: $NAME
       - name: Push to s3 bucket
         id: push-wheel
-        uses: neuralmagic/nm-actions/actions/s3_push@pypi-actions
+        uses: neuralmagic/nm-actions/actions/s3_push
         with:
           filename: dist/*.whl
           internal: $INTERNAL

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -45,14 +45,14 @@ jobs:
           aws-region: us-east-1 
       - name: Build PyPi Wheel
         id: build-wheel
-        uses: neuralmagic/nm-actions/actions/pypi_build
+        uses: neuralmagic/nm-actions/actions/pypi_build@main
         with:
           dev: $DEV
           release: $RELEASE
           name: $NAME
       - name: Push to s3 bucket
         id: push-wheel
-        uses: neuralmagic/nm-actions/actions/s3_push
+        uses: neuralmagic/nm-actions/actions/s3_push@main
         with:
           filename: dist/*.whl
           internal: $INTERNAL

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,0 +1,58 @@
+name: Build PyPi Wheel
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - 'release/**'
+  push:
+    branches:
+      - main
+  release:
+    types: [created, published]
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+# if not dev or release, will create a nightly build
+# everything is pushed to internal unless created through a nightly scheduled cron job which creates the build or 
+# missing release tag workflow/needs to be added in
+env:
+  INTERNAL: ${{ github.event_name != 'schedule' && github.event_name != 'release'}}
+  RELEASE: ${{ github.event_name =='release' || (github.base_ref == 'release/**' && github.event_name == 'pull_request')}}
+  DEV: ${{ github.base_ref == 'main' && github.event_name == 'pull_request'}}
+  NAME: ${{ github.event.number }} 
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    outputs:
+      wheel: ${{ steps.push-wheel.outputs.wheel }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Login to s3
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_WEBIDENTITY_FOR_GITHUB_ACTIONS }}
+          aws-region: us-east-1 
+      - name: Build PyPi Wheel
+        id: build-wheel
+        uses: neuralmagic/nm-actions/actions/pypi_build@pypi-actions
+        with:
+          dev: $DEV
+          release: $RELEASE
+          name: $NAME
+      - name: Push to s3 bucket
+        id: push-wheel
+        uses: neuralmagic/nm-actions/actions/s3_push@pypi-actions
+        with:
+          filename: dist/*.whl
+          internal: $INTERNAL

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ from setuptools import find_packages, setup
 
 # default variables to be overwritten by the version.py file
 is_release = None
+is_dev = None
 version = "unknown"
 version_base = version
 
@@ -37,7 +38,12 @@ version_base = version
 exec(open(os.path.join("src", "sparsezoo", "version.py")).read())
 print(f"loaded version {version} from src/sparsezoo/version.py")
 
-_PACKAGE_NAME = "sparsezoo" if is_release else "sparsezoo-nightly"
+if is_release:
+    _PACKAGE_NAME = "sparsezoo"
+elif is_dev:
+    _PACKAGE_NAME = "sparsezoo-dev"
+else:
+    _PACKAGE_NAME = "sparsezoo-nightly"
 
 _deps = [
     "numpy>=1.0.0",

--- a/src/sparsezoo/version.py
+++ b/src/sparsezoo/version.py
@@ -22,14 +22,17 @@ from datetime import date
 
 version_base = "1.7.0"
 is_release = False  # change to True to set the generated version as a release version
+is_dev = False
+dev_number = None
 
 
 def _generate_version():
-    return (
-        version_base
-        if is_release
-        else f"{version_base}.{date.today().strftime('%Y%m%d')}"
-    )
+    if is_release:
+        return version_base
+    elif is_dev:
+        return f"{version_base}.dev{dev_number}"
+    else:
+        return f"{version_base}.{date.today().strftime('%Y%m%d')}"
 
 
 __all__ = [


### PR DESCRIPTION
# Summary
- Add a workflow which based on the conditions, will create a nightly, dev or release wheel
- The workflows make use of the actions in `nm-actions` and relies on this PR: https://github.com/neuralmagic/nm-actions/pull/3
- The following cases are covered:

## 1. Dev
- For dev, a wheel is created if a PR to main is opened or updated. This wheel will be called `sparsezoo_dev-[version].dev[PR]` where [PR] will be replaced to use the PR number and [version] will be replaced to the current version listed in `version.py`. All dev PRs are pushed to the internal bucket in s3 (from which jenkins should push to the internal PyPi server)

## 2. Release
- When a PR is opened/updated to a release branch: in that case, the built wheel will be pushed to the internal bucket in s3 and the wheel will be called `sparsezoo-[version]` where the [version] will be replaced to the current version listed in `version.py` 
- When a new release tag is cut, the naming will be the same however, the release will be pushed to the external/production s3 bucket for the production PyPi server

## 3. Nightly
- When a PR is merged into main, the wheel will be built and named `sparsezoo_nightly-[version].[date]`
- A scheduled nightly cron job will trigger a nightly build and create a wheel with the same name. The wheel will be pushed to an external/production s3 bucket for the production PyPi server

The equivalent workflow can be added in to sparseml once approved

# Testing
- Nightly and dev workflows have been tested however, this is with a dummy s3 bucket so we do not overload the buckets being used by the current workflow
- Release builds have not been tested 

# NOTE:
- Before this PR can be merged, the actions PR mentioned above must be merged

# Next Steps:
- Update jenkins to use the new/updated buckets
- Find a non-destructive way to test release workflows 