### PR TITLE
Multiple download bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,10 +411,6 @@ For a more in-depth read, check out [SparseZoo documentation.](https://docs.neur
 - Documentation: [SparseML,](https://docs.neuralmagic.com/sparseml/) [SparseZoo,](https://docs.neuralmagic.com/sparsezoo/) [Sparsify,](https://docs.neuralmagic.com/sparsify/) [DeepSparse](https://docs.neuralmagic.com/deepsparse/)
 - Neural Magic: [Blog,](https://www.neuralmagic.com/blog/) [Resources](https://www.neuralmagic.com/resources/)
 
-### Tests
-
-
-
 ### Release History
 
 Official builds are hosted on PyPI

--- a/README.md
+++ b/README.md
@@ -411,6 +411,10 @@ For a more in-depth read, check out [SparseZoo documentation.](https://docs.neur
 - Documentation: [SparseML,](https://docs.neuralmagic.com/sparseml/) [SparseZoo,](https://docs.neuralmagic.com/sparsezoo/) [Sparsify,](https://docs.neuralmagic.com/sparsify/) [DeepSparse](https://docs.neuralmagic.com/deepsparse/)
 - Neural Magic: [Blog,](https://www.neuralmagic.com/blog/) [Resources](https://www.neuralmagic.com/resources/)
 
+### Tests
+
+
+
 ### Release History
 
 Official builds are hosted on PyPI


### PR DESCRIPTION
Ticket:
https://app.asana.com/0/1206109050183159/1206698210421769

Fix for multiple processing running the download code. 
Problem with the previous code is that once the download happens, it generates a folder name by the filename in the temp file and saves the chunk files there. If multiple download of the same file happens, the downloading folder can be deleted while downloading. 
Solution is to make a file_id for each download call and save it in there before going into the original download folder path. 

