### PR TITLE
[BugFix] Fix Serialization of Computed Properties in BaseModel

### DIFF
--- a/src/sparsezoo/analyze_v1/analysis.py
+++ b/src/sparsezoo/analyze_v1/analysis.py
@@ -103,6 +103,13 @@ class YAMLSerializableBaseModel(BaseModel):
     A BaseModel that adds a .yaml(...) function to all child classes
     """
 
+    model_config = ConfigDict(protected_namespaces=())
+
+    def dict(self, *args, **kwargs) -> Dict[str, Any]:
+        # alias for model_dump for pydantic v2 upgrade
+        # to allow for easier migration
+        return self.model_dump(*args, **kwargs)
+
     def yaml(self, file_path: Optional[str] = None) -> Union[str, None]:
         """
         :param file_path: optional file path to save yaml to
@@ -111,7 +118,7 @@ class YAMLSerializableBaseModel(BaseModel):
         """
         file_stream = None if file_path is None else open(file_path, "w")
         ret = yaml.dump(
-            self.dict(), stream=file_stream, allow_unicode=True, sort_keys=False
+            self.model_dump(), stream=file_stream, allow_unicode=True, sort_keys=False
         )
 
         if file_stream is not None:
@@ -127,7 +134,7 @@ class YAMLSerializableBaseModel(BaseModel):
         """
         with open(file_path, "r") as file:
             dict_obj = yaml.safe_load(file)
-        return cls.parse_obj(dict_obj)
+        return cls.model_validate(dict_obj)
 
     @classmethod
     def parse_yaml_raw(cls, yaml_raw: str):
@@ -136,7 +143,7 @@ class YAMLSerializableBaseModel(BaseModel):
         :return: instance of ModelAnalysis class
         """
         dict_obj = yaml.safe_load(yaml_raw)  # unsafe: needs to load numpy
-        return cls.parse_obj(dict_obj)
+        return cls.model_validate(dict_obj)
 
 
 @dataclass

--- a/tests/sparsezoo/analyze/test_analysis/test_models.py
+++ b/tests/sparsezoo/analyze/test_analysis/test_models.py
@@ -1,0 +1,14 @@
+from sparsezoo.analyze_v1.utils.models import DenseSparseOps, ZeroNonZeroParams
+import pytest
+
+@pytest.mark.parametrize("model", [DenseSparseOps, ZeroNonZeroParams])
+@pytest.mark.parametrize("computed_fields", [
+    ["sparsity"]
+    ]
+                         )
+def test_model_dump_has_computed_fields(model, computed_fields):
+    model = model()
+    model_dict = model.model_dump()
+    for computed_field in computed_fields:
+        assert computed_field in model_dict
+        assert model_dict[computed_field] == getattr(model, computed_field)    

--- a/tests/sparsezoo/analyze/test_analysis/test_models.py
+++ b/tests/sparsezoo/analyze/test_analysis/test_models.py
@@ -1,14 +1,27 @@
-from sparsezoo.analyze_v1.utils.models import DenseSparseOps, ZeroNonZeroParams
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
+from sparsezoo.analyze_v1.utils.models import DenseSparseOps, ZeroNonZeroParams
+
+
 @pytest.mark.parametrize("model", [DenseSparseOps, ZeroNonZeroParams])
-@pytest.mark.parametrize("computed_fields", [
-    ["sparsity"]
-    ]
-                         )
+@pytest.mark.parametrize("computed_fields", [["sparsity"]])
 def test_model_dump_has_computed_fields(model, computed_fields):
     model = model()
     model_dict = model.model_dump()
     for computed_field in computed_fields:
         assert computed_field in model_dict
-        assert model_dict[computed_field] == getattr(model, computed_field)    
+        assert model_dict[computed_field] == getattr(model, computed_field)


### PR DESCRIPTION
#### Description:
A bug was identified where computed properties in the base model were not serialized correctly due to an overridden dict() method. The method was initially designed to inject properties, but since the introduction of model_dump as a naming convention, it no longer executed the necessary code when yaml() was called.

#### Fixes Included:

- Introduced an alias for dict() that delegates to model_dump to resolve naming conflicts.
- Used the computed_fields decorator from Pydantic v2 for properties that require serialization.
- Got rid of original `PropertyBaseModel`

#### Test Plan:
- Added a new unit test to ensure that the `model_dump()` method correctly returns a dictionary with the computed fields. This test fails on the main branch but passes on this branch.
- Confirmed that the original test failures are resolved with this update.
    - [TestDeepsparse-7308](http://dash.neuralmagic.com/junit/TestDeepsparse-7308/test-results/github-examples.xml.html#b0b36313-a9fb-4b4e-b98a-f84fdedf3a37)
    - [TestSparsezoo-5680](http://dash.neuralmagic.com/junit/TestSparsezoo-5680/report.unit.html)

