### PR TITLE
hotfix 1.8.1 to relax pydantic version restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ _deps = [
     "pyyaml>=5.1.0",
     "requests>=2.0.0",
     "tqdm>=4.0.0",
-    "pydantic>=2.0.0,<2.8",
+    "pydantic~=2.0",
     "click>=7.1.2,!=8.0.0",  # latest version < 8.0 + blocked version with reported bug
     "protobuf>=3.12.2",
     "pandas>1.3",

--- a/src/sparsezoo/version.py
+++ b/src/sparsezoo/version.py
@@ -20,7 +20,7 @@ Functionality for storing and setting the version info for SparseZoo
 from datetime import date
 
 
-version_base = "1.8.0"
+version_base = "1.8.1"
 is_release = False  # change to True to set the generated version as a release version
 is_dev = False
 dev_number = None


### PR DESCRIPTION
For release/1.8 branch